### PR TITLE
Apple fonttools fixes

### DIFF
--- a/AppKit/NSFontDescriptor.m
+++ b/AppKit/NSFontDescriptor.m
@@ -41,6 +41,8 @@ NSString *const NSFontWeightTrait = @"NSFontWeightTrait";
 NSString *const NSFontWidthTrait = @"NSFontWidthTrait";
 NSString *const NSFontSlantTrait = @"NSFontSlantTrait";
 
+NSString *const NSFontFeatureSelectorIdentifierKey = @"NSFontFeatureSelectorIdentifier";
+
 const NSFontWeight NSFontWeightThin = 0xbfe3333340000000;
 const NSFontWeight NSFontWeightLight = 0xbfd99999a0000000;
 const NSFontWeight NSFontWeightUltraLight = 0xbfe99999a0000000;

--- a/AppKit/NSFontDescriptor.m
+++ b/AppKit/NSFontDescriptor.m
@@ -42,6 +42,7 @@ NSString *const NSFontWidthTrait = @"NSFontWidthTrait";
 NSString *const NSFontSlantTrait = @"NSFontSlantTrait";
 
 NSString *const NSFontFeatureSelectorIdentifierKey = @"NSFontFeatureSelectorIdentifier";
+NSString *const NSFontFeatureTypeIdentifierKey = @"NSFontFeatureTypeIdentifierKey";
 
 const NSFontWeight NSFontWeightThin = 0xbfe3333340000000;
 const NSFontWeight NSFontWeightLight = 0xbfd99999a0000000;

--- a/CoreGraphics/CGFont.m
+++ b/CoreGraphics/CGFont.m
@@ -20,6 +20,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #import <CoreGraphics/CGFont.h>
 #import <Onyx2D/O2Font.h>
 
+const CFStringRef kCGFontNameKeyCopyright = CFSTR("CGFontNameKeyCopyright");
+
 CGFontRef CGFontCreateWithFontName(CFStringRef name) {
     return O2FontCreateWithFontName((NSString *) name);
 }

--- a/CoreGraphics/CGFont.m
+++ b/CoreGraphics/CGFont.m
@@ -21,6 +21,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #import <Onyx2D/O2Font.h>
 
 const CFStringRef kCGFontNameKeyCopyright = CFSTR("CGFontNameKeyCopyright");
+const CFStringRef kCGFontNameKeyFontFamily = CFSTR("CGFontNameKeyFontFamily");
+const CFStringRef kCGFontNameKeyFontSubfamily = CFSTR("CGFontNameKeyFontSubfamily");
+const CFStringRef kCGFontNameKeyFullName = CFSTR("CGFontNameKeyFullName");
+const CFStringRef kCGFontNameKeyPostScriptName = CFSTR("CGFontNameKeyPostScriptName");
+const CFStringRef kCGFontNameKeyPreferredFamily = CFSTR("CGFontNameKeyPreferredFamily");
+const CFStringRef kCGFontNameKeyPreferredSubfamily = CFSTR("CGFontNameKeyPreferredSubfamily");
+const CFStringRef kCGFontNameKeyVersion = CFSTR("CGFontNameKeyPreferredSubfamily");
 
 CGFontRef CGFontCreateWithFontName(CFStringRef name) {
     return O2FontCreateWithFontName((NSString *) name);

--- a/CoreText/constants.c
+++ b/CoreText/constants.c
@@ -41,4 +41,7 @@ const CFStringRef kCTLanguageAttributeName = CFSTR("CTLanguageAttributeName");
 const CFStringRef kCTTypesetterOptionForcedEmbeddingLevel = CFSTR("CTTypesetterOptionForcedEmbeddingLevel");
 const CFStringRef kCTVerticalFormsAttributeName = CFSTR("CTVerticalFormsAttributeName");
 const CFStringRef kCTFontFullNameKey = CFSTR("CTFontFullName");
+const CFStringRef kCTFontStyleNameKey = CFSTR("CTFontStyleName");
+const CFStringRef kCTFontUniqueNameKey = CFSTR("CTFontUniqueName");
+const CFStringRef kCTFontVersionNameKey = CFSTR("CTFontVersionName");
 const CFStringRef kCTFontFeaturesAttribute = CFSTR("CTFontFeaturesAttribute");

--- a/CoreText/constants.c
+++ b/CoreText/constants.c
@@ -41,3 +41,4 @@ const CFStringRef kCTLanguageAttributeName = CFSTR("CTLanguageAttributeName");
 const CFStringRef kCTTypesetterOptionForcedEmbeddingLevel = CFSTR("CTTypesetterOptionForcedEmbeddingLevel");
 const CFStringRef kCTVerticalFormsAttributeName = CFSTR("CTVerticalFormsAttributeName");
 const CFStringRef kCTFontFullNameKey = CFSTR("CTFontFullName");
+const CFStringRef kCTFontFeaturesAttribute = CFSTR("CTFontFeaturesAttribute");

--- a/CoreText/constants.c
+++ b/CoreText/constants.c
@@ -40,3 +40,4 @@ const CFStringRef kCTKernAttributeName = CFSTR("CTKernAttributeName");
 const CFStringRef kCTLanguageAttributeName = CFSTR("CTLanguageAttributeName");
 const CFStringRef kCTTypesetterOptionForcedEmbeddingLevel = CFSTR("CTTypesetterOptionForcedEmbeddingLevel");
 const CFStringRef kCTVerticalFormsAttributeName = CFSTR("CTVerticalFormsAttributeName");
+const CFStringRef kCTFontFullNameKey = CFSTR("CTFontFullName");


### PR DESCRIPTION
Various missing symbols required for Apple's font tool suite to run. Not sure about the sort order of things, but at least the changes go into the right files.

Please review.