### PR TITLE
On MacOS, main menu items display the title of their sub-menu rather than their own title

### DIFF
--- a/AppKit/NSMenu.subproj/NSMainMenuView.m
+++ b/AppKit/NSMenu.subproj/NSMainMenuView.m
@@ -86,7 +86,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
          previousBorderRect: (NSRect) previousBorderRect
 {
     NSRect result;
-    NSSize titleSize = [[self graphicsStyle] menuItemTextSize: [item title]];
+    NSSize titleSize = [[self graphicsStyle] menuItemTextSize: [item _mainMenuTitle]];
 
     result.origin = NSMakePoint(
             NSMaxX(previousBorderRect) + 6,
@@ -121,7 +121,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
     for (i = 0; i < count; i++) {
         NSMenuItem *item = [items objectAtIndex: i];
-        NSString *title = [item title];
+        NSString *title = [item _mainMenuTitle];
         NSSize size = [title sizeWithAttributes: [self titleAttributes]];
 
         height = MAX(height, size.height);
@@ -191,7 +191,7 @@ static void drawSunkenBorder(NSRect rect) {
 
     for (i = 0; i < count; i++) {
         NSMenuItem *item = [items objectAtIndex: i];
-        NSString *title = [item title];
+        NSString *title = [item _mainMenuTitle];
         NSRect titleRect = [self titleRectForItem: item
                                previousBorderRect: previousBorderRect];
         NSRect borderRect = [self borderRectFromTitleRect: titleRect];

--- a/AppKit/NSMenu.subproj/NSMenuItem.m
+++ b/AppKit/NSMenu.subproj/NSMenuItem.m
@@ -397,4 +397,20 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
                              ([self hasSubmenu] ? @"YES" : @"NO")];
 }
 
+// This is used by NSMainMenuView To Display The Correct Title
+- (NSString *) _mainMenuTitle {
+    // On MacOS, main menu items display the title of their sub-menu rather than their own title
+    if ([[self menu] supermenu] == nil) {
+        // Check if sub-menu exists
+        if ([self hasSubmenu]) {
+            // Check if sub-menu title exists
+            NSString *submenuTitle = [[self submenu] title];
+            if (submenuTitle != nil) {
+                return submenuTitle;
+            }
+        }
+    }
+    return _title;
+}
+
 @end

--- a/AppKit/include/AppKit/NSMenuItem.h
+++ b/AppKit/include/AppKit/NSMenuItem.h
@@ -100,4 +100,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 - (NSString *) _keyEquivalentDescription;
 
+- (NSString *) _mainMenuTitle;
+
 @end


### PR DESCRIPTION
Fixes darlinghq/darling#679