### PR TITLE
Add ``+[NSColor colorWithSRGBRed]`` And ``+[NSColor colorWithRed]``

### DIFF
--- a/AppKit/NSColor.subproj/NSColor.m
+++ b/AppKit/NSColor.subproj/NSColor.m
@@ -562,6 +562,17 @@ NSString *const NSSystemColorsDidChangeNotification = @"NSSystemColorsDidChangeN
                                spaceName: NSDeviceRGBColorSpace];
 }
 
++ (NSColor *) colorWithRed: (CGFloat) red
+                     green: (CGFloat) green
+                      blue: (CGFloat) blue
+                     alpha: (CGFloat) alpha
+{
+    return [NSColor colorWithDeviceRed: red
+                                 green: green
+                                  blue: blue
+                                 alpha: alpha];
+}
+
 + (NSColor *) colorWithSRGBRed: (CGFloat) red
                          green: (CGFloat) green
                           blue: (CGFloat) blue

--- a/AppKit/NSColor.subproj/NSColor.m
+++ b/AppKit/NSColor.subproj/NSColor.m
@@ -562,6 +562,18 @@ NSString *const NSSystemColorsDidChangeNotification = @"NSSystemColorsDidChangeN
                                spaceName: NSDeviceRGBColorSpace];
 }
 
++ (NSColor *) colorWithSRGBRed: (CGFloat) red
+                         green: (CGFloat) green
+                          blue: (CGFloat) blue
+                         alpha: (CGFloat) alpha
+{
+    return [NSColor_CGColor colorWithRed: red
+                                   green: green
+                                    blue: blue
+                                   alpha: alpha
+                               spaceName: NSNamedColorSpace];
+}
+
 + (NSColor *) colorWithDeviceHue: (CGFloat) hue
                       saturation: (CGFloat) saturation
                       brightness: (CGFloat) brightness

--- a/AppKit/include/AppKit/NSColor.h
+++ b/AppKit/include/AppKit/NSColor.h
@@ -97,6 +97,10 @@ APPKIT_EXPORT NSString *const NSSystemColorsDidChangeNotification;
                            green: (CGFloat) green
                             blue: (CGFloat) blue
                            alpha: (CGFloat) alpha;
++ (NSColor *) colorWithRed: (CGFloat) red
+                     green: (CGFloat) green
+                      blue: (CGFloat) blue
+                     alpha: (CGFloat) alpha;
 + (NSColor *) colorWithSRGBRed: (CGFloat) red
                          green: (CGFloat) green
                           blue: (CGFloat) blue

--- a/AppKit/include/AppKit/NSColor.h
+++ b/AppKit/include/AppKit/NSColor.h
@@ -97,6 +97,10 @@ APPKIT_EXPORT NSString *const NSSystemColorsDidChangeNotification;
                            green: (CGFloat) green
                             blue: (CGFloat) blue
                            alpha: (CGFloat) alpha;
++ (NSColor *) colorWithSRGBRed: (CGFloat) red
+                         green: (CGFloat) green
+                          blue: (CGFloat) blue
+                         alpha: (CGFloat) alpha;
 + (NSColor *) colorWithDeviceHue: (CGFloat) hue
                       saturation: (CGFloat) saturation
                       brightness: (CGFloat) brightness


### PR DESCRIPTION
According to https://stackoverflow.com/a/12568535 SRGB is a ``NSNamedColorSpace`` so I used that. This fixes https://github.com/gammasoft71/Examples_Cocoa/blob/master/src/HelloWorlds/HelloWorld/HelloWorld.m.