### PR TITLE
alertWithMessageText fix and NSInteger-ization of NSAlert.m

### DIFF
--- a/AppKit/NSAlert.m
+++ b/AppKit/NSAlert.m
@@ -128,7 +128,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
     [result setMessageText: [error localizedDescription]];
     [result setInformativeText: [error localizedRecoverySuggestion]];
-    int i, count = [titles count];
+    NSUInteger i, count = [titles count];
     for (i = 0; i < count; i++)
         [result addButtonWithTitle: [titles objectAtIndex: i]];
 
@@ -332,7 +332,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     CGFloat suppressionAccessoryGap = 0.;
     NSSize mainSize = NSZeroSize;
     NSSize panelSize = NSZeroSize;
-    int i, count = [_buttons count];
+    NSUInteger i, count = [_buttons count];
     NSSize okCancelButtonSize = NSMakeSize(40, 24);
     NSSize otherButtonSize = okCancelButtonSize;
     NSSize allButtonsSize = NSZeroSize;
@@ -545,10 +545,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 }
 
 - (void) sheetDidEnd: (NSWindow *) sheet
-          returnCode: (int) returnCode
+          returnCode: (NSModalResponse) returnCode
          contextInfo: (void *) contextInfo
 {
-    typedef void (*alertDidEnd)(id, SEL, NSAlert *, int, void *);
+    typedef void (*alertDidEnd)(id, SEL, NSAlert *, NSModalResponse, void *);
     if (_sheetDidEnd) {
         alertDidEnd endFunction =
                 (alertDidEnd) [_sheetDelegate methodForSelector: _sheetDidEnd];
@@ -589,7 +589,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
                        contextInfo: 0];
 }
 
-- (NSInteger) runModal {
+- (NSModalResponse) runModal {
     [_window setLevel: NSModalPanelWindowLevel];
     [_window setStyleMask: NSTitledWindowMask];
     [self layoutIfNeeded];

--- a/AppKit/NSAlert.m
+++ b/AppKit/NSAlert.m
@@ -115,6 +115,24 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     [super dealloc];
 }
 
+- (NSButton *) _addButtonWithTitle: (NSString *) title
+                        returnCode: (NSModalResponse) returnCode
+{
+    NSButton *result = [[NSButton alloc] init];
+    [result setTitle: title];
+    [result setTarget: self];
+    [result setAction: @selector(_alertButton:)];
+    [result setTag: returnCode];
+    [_buttons addObject: result];
+    _needsLayout = YES;
+    return result;
+}
+
+- (NSButton *) addButtonWithTitle: (NSString *) title {
+    return [self _addButtonWithTitle: title 
+                          returnCode: NSAlertFirstButtonReturn + [_buttons count]];
+}
+
 + (NSAlert *) alertWithError: (NSError *) error {
     NSArray *titles = [error localizedRecoveryOptions];
     NSString *defaultTitle =
@@ -158,11 +176,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
         defaultTitle = NSLocalizedStringFromTableInBundle(
                 @"OK", nil, [NSBundle bundleForClass: [NSAlert class]],
                 @"Default button title for NSAlert");
-    [result _addButtonWithTitle: defaultTitle returnCode:NSAlertDefaultReturn];
+    [result _addButtonWithTitle: defaultTitle 
+                     returnCode: NSAlertDefaultReturn];
     if (alternateTitle != nil)
-        [result _addButtonWithTitle: alternateTitle returnCode:NSAlertAlternateReturn];
+        [result _addButtonWithTitle: alternateTitle 
+                         returnCode: NSAlertAlternateReturn];
     if (otherTitle != nil)
-        [result _addButtonWithTitle: otherTitle returnCode:NSAlertOtherReturn];
+        [result _addButtonWithTitle: otherTitle
+                         returnCode: NSAlertOtherReturn];
 
     return result;
 }
@@ -274,23 +295,6 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     [_helpAnchor release];
     _helpAnchor = anchor;
     _needsLayout = YES;
-}
-
-- (NSButton *) _addButtonWithTitle: (NSString *) title
-                        returnCode: (NSModalResponse) returnCode
-{
-    NSButton *result = [[NSButton alloc] init];
-    [result setTitle: title];
-    [result setTarget: self];
-    [result setAction: @selector(_alertButton:)];
-    [result setTag: returnCode];
-    [_buttons addObject: result];
-    _needsLayout = YES;
-    return result;
-}
-
-- (NSButton *) addButtonWithTitle: (NSString *) title {
-    return [self _addButtonWithTitle:title returnCore:NSAlertFirstButtonReturn + [_buttons count]];
 }
 
 - (void) layout {

--- a/AppKit/NSAlert.m
+++ b/AppKit/NSAlert.m
@@ -158,11 +158,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
         defaultTitle = NSLocalizedStringFromTableInBundle(
                 @"OK", nil, [NSBundle bundleForClass: [NSAlert class]],
                 @"Default button title for NSAlert");
-    [result addButtonWithTitle: defaultTitle];
+    [result _addButtonWithTitle: defaultTitle returnCode:NSAlertDefaultReturn];
     if (alternateTitle != nil)
-        [result addButtonWithTitle: alternateTitle];
+        [result _addButtonWithTitle: alternateTitle returnCode:NSAlertAlternateReturn];
     if (otherTitle != nil)
-        [result addButtonWithTitle: otherTitle];
+        [result _addButtonWithTitle: otherTitle returnCode:NSAlertOtherReturn];
 
     return result;
 }
@@ -276,15 +276,21 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     _needsLayout = YES;
 }
 
-- (NSButton *) addButtonWithTitle: (NSString *) title {
+- (NSButton *) _addButtonWithTitle: (NSString *) title
+                        returnCode: (NSModalResponse) returnCode
+{
     NSButton *result = [[NSButton alloc] init];
     [result setTitle: title];
     [result setTarget: self];
     [result setAction: @selector(_alertButton:)];
-    [result setTag: NSAlertFirstButtonReturn + [_buttons count]];
+    [result setTag: returnCode];
     [_buttons addObject: result];
     _needsLayout = YES;
     return result;
+}
+
+- (NSButton *) addButtonWithTitle: (NSString *) title {
+    return [self _addButtonWithTitle:title returnCore:NSAlertFirstButtonReturn + [_buttons count]];
 }
 
 - (void) layout {

--- a/AppKit/NSAlert.m
+++ b/AppKit/NSAlert.m
@@ -124,6 +124,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     [result setAction: @selector(_alertButton:)];
     [result setTag: returnCode];
     [_buttons addObject: result];
+    [result release];
     _needsLayout = YES;
     return result;
 }


### PR DESCRIPTION
This PR fixes wrong `NSModalResponse` for alerts created with [alertWithMessageText](https://developer.apple.com/documentation/appkit/nsalert/1550982-alertwithmessagetext)
Additionally, it also replaces all wrongful `int` within `NSAlert.m`