### PR TITLE
Fix 1351 wrong nsstringdrawer truncating text

### DIFF
--- a/AppKit/NSStringDrawer.h
+++ b/AppKit/NSStringDrawer.h
@@ -19,6 +19,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #import <AppKit/AppKitExport.h>
+#import <AppKit/NSParagraphStyle.h>
 #import <Foundation/Foundation.h>
 
 @class NSTextStorage, NSLayoutManager, NSTextContainer;
@@ -38,9 +39,11 @@ APPKIT_EXPORT const CGFloat NSStringDrawerLargeDimension;
 - (NSSize) sizeOfString: (NSString *) string
          withAttributes: (NSDictionary *) attributes
                  inSize: (NSSize) maxSize;
+
 - (void) drawString: (NSString *) string
         withAttributes: (NSDictionary *) attributes
                 inRect: (NSRect) rect;
+
 // Use a size of NSZeroSize for unlimited dimensions.
 - (void) drawString: (NSString *) string
         withAttributes: (NSDictionary *) attributes
@@ -50,8 +53,10 @@ APPKIT_EXPORT const CGFloat NSStringDrawerLargeDimension;
 // Use a size of NSZeroSize for unlimited dimensions.
 - (NSSize) sizeOfAttributedString: (NSAttributedString *) astring
                            inSize: (NSSize) maxSize;
+
 - (void) drawAttributedString: (NSAttributedString *) astring
                        inRect: (NSRect) rect;
+                       
 // Use a size of NSZeroSize for unlimited dimensions.
 - (void) drawAttributedString: (NSAttributedString *) astring
                       atPoint: (NSPoint) point
@@ -69,11 +74,15 @@ APPKIT_EXPORT const CGFloat NSStringDrawerLargeDimension;
 - (void) _clipAndDrawInRect: (NSRect) rect
              withAttributes: (NSDictionary *) attributes;
 
+- (void) _clipAndDrawInRect:(NSRect)rect 
+             lineBreakMode:(NSLineBreakMode)lineBreakMode;
+
 @end
 
 @interface NSAttributedString (NSStringDrawer_private)
 
-- (void) _clipAndDrawInRect: (NSRect) rect truncatingTail: (BOOL) truncateTail;
+- (void) _clipAndDrawInRect: (NSRect) rect 
+             truncatingTail: (BOOL) truncateTail;
 
 - (void) _clipAndDrawInRect: (NSRect) rect;
 

--- a/AppKit/NSStringDrawer.m
+++ b/AppKit/NSStringDrawer.m
@@ -310,6 +310,8 @@ const CGFloat NSStringDrawerLargeDimension = 1000000.;
                     break;
                 default:
                     // NSLineBreakByClipping
+                    clippedTitle = [string attributedSubstringFromRange:NSMakeRange(0, mid)];
+                    tmpString = [[[NSAttributedString alloc] initWithAttributedString:clippedTitle] mutableCopy];
                     break;
             }
 
@@ -346,10 +348,18 @@ const CGFloat NSStringDrawerLargeDimension = 1000000.;
 
             default:
                 // NSLineBreakByClipping
+                clippedTitle = [string attributedSubstringFromRange:NSMakeRange(0, left - 1)];
+                tmpString = [[[NSAttributedString alloc] initWithAttributedString:clippedTitle] mutableCopy];
                 break;
         }
 
         string = tmpString;
+    }
+
+    if (lineBreakMode == NSLineBreakByClipping) {
+        NSStringDrawingOptions options = NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine;
+        CGRect drawingRect = CGRectMake(rect.origin.x, rect.origin.y, rect.size.width, CGFLOAT_MAX);
+        [string boundingRectWithSize:drawingRect.size options:options context:nil];
     }
 
     [[NSStringDrawer sharedStringDrawer] drawAttributedString:string inRect:rect];

--- a/AppKit/NSStringDrawer.m
+++ b/AppKit/NSStringDrawer.m
@@ -304,10 +304,12 @@ const CGFloat NSStringDrawerLargeDimension = 1000000.;
                     break;
 
                 case NSLineBreakByTruncatingTail:
-                default:
                     clippedTitle = [string attributedSubstringFromRange:NSMakeRange(0, mid)];
                     tmpString = [[[NSAttributedString alloc] initWithAttributedString:clippedTitle] mutableCopy];
                     [tmpString appendAttributedString:ellipsis];
+                    break;
+                default:
+                    // NSLineBreakByClipping
                     break;
             }
 

--- a/AppKit/NSTableHeaderCell.m
+++ b/AppKit/NSTableHeaderCell.m
@@ -48,6 +48,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
             drawTableViewHeaderInRect: cellFrame
                           highlighted: [self isHighlighted]];
 
+    // Draw the title
     [[self attributedStringValue]
             _clipAndDrawInRect: [self titleRectForBounds: cellFrame]
                  lineBreakMode: _lineBreakMode];                

--- a/AppKit/NSTableHeaderCell.m
+++ b/AppKit/NSTableHeaderCell.m
@@ -48,7 +48,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
             drawTableViewHeaderInRect: cellFrame
                           highlighted: [self isHighlighted]];
 
-    // Draw the title
+    // Draw the title respecting the line break mode
     [[self attributedStringValue]
             _clipAndDrawInRect: [self titleRectForBounds: cellFrame]
                  lineBreakMode: _lineBreakMode];                

--- a/AppKit/NSTableHeaderCell.m
+++ b/AppKit/NSTableHeaderCell.m
@@ -47,9 +47,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     [[controlView graphicsStyle]
             drawTableViewHeaderInRect: cellFrame
                           highlighted: [self isHighlighted]];
+
     [[self attributedStringValue]
             _clipAndDrawInRect: [self titleRectForBounds: cellFrame]
-                truncatingTail: (_lineBreakMode > NSLineBreakByClipping)];
+                 lineBreakMode: _lineBreakMode];                
 }
 
 @end

--- a/AppKit/NSTextFieldCell.m
+++ b/AppKit/NSTextFieldCell.m
@@ -353,8 +353,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
             drawValue = placeString;
         }
     }
+
     [drawValue _clipAndDrawInRect: titleRect
-                   truncatingTail: _lineBreakMode > NSLineBreakByClipping];
+                    lineBreakMode: _lineBreakMode];
 }
 
 static void drawRoundedBezel(CGContextRef context, CGRect frame) {

--- a/AppKit/NSTextFieldCell.m
+++ b/AppKit/NSTextFieldCell.m
@@ -353,9 +353,12 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
             drawValue = placeString;
         }
     }
+//    [drawValue _clipAndDrawInRect: titleRect
+//                   truncatingTail: _lineBreakMode > NSLineBreakByClipping];
 
     [drawValue _clipAndDrawInRect: titleRect
                     lineBreakMode: _lineBreakMode];
+
 }
 
 static void drawRoundedBezel(CGContextRef context, CGRect frame) {

--- a/AppKit/NSTextFieldCell.m
+++ b/AppKit/NSTextFieldCell.m
@@ -353,12 +353,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
             drawValue = placeString;
         }
     }
-//    [drawValue _clipAndDrawInRect: titleRect
-//                   truncatingTail: _lineBreakMode > NSLineBreakByClipping];
 
     [drawValue _clipAndDrawInRect: titleRect
                     lineBreakMode: _lineBreakMode];
-
 }
 
 static void drawRoundedBezel(CGContextRef context, CGRect frame) {


### PR DESCRIPTION
This fix solves two problems:
- String drawing performance is very slow when truncating large texts
- String drawing does not properly truncate NSLineBreakByTruncatingHead and NSLineBreakByTruncatingMiddle

This pull request is related with reported bug:

https://github.com/darlinghq/darling/issues/1351

That can be closed after the merging