### PR TITLE
AppKit Improvements (Getting TextEdit to compile and Run)

### DIFF
--- a/AppKit/NSAttributedString.m
+++ b/AppKit/NSAttributedString.m
@@ -129,6 +129,8 @@ NSString *const NSCharacterShapeAttributeName = @"NSCharacterShape";
 NSString *const NSUsesScreenFontsDocumentAttribute = @"UsesScreenFonts";
 
 NSString *const NSTextEffectAttributeName = @"NSTextEffect";
+NSAttributedStringKey NSWritingDirectionAttributeName = @"NSWritingDirectionAttribute";
+NSString *const NSCocoaVersionDocumentAttribute  = @"NSCocoaVersionDocumentAttribute";
 
 NSUInteger NSUnderlineStrikethroughMask = 0x4000;
 NSUInteger NSUnderlineByWordMask = 0x8000;
@@ -157,6 +159,53 @@ NSUInteger NSUnderlineByWordMask = 0x8000;
                      error: (NSError **) error
 {
     NSUnimplementedMethod();
+    NSString *docType = [options objectForKey:NSDocumentTypeDocumentAttribute];
+    
+    if(docType == nil){
+        NSLog(@"NSAttributedString initFromData - inferring document type");
+        //TODO: infer document type (assume RTF for now)
+        docType = NSRTFTextDocumentType;
+    }
+
+    //Read the document based on its type
+    if([docType isEqual: NSDocFormatTextDocumentType]){
+        return nil;
+    }
+    else if([docType isEqual: NSHTMLTextDocumentType]){
+        NSLog(@"NSAttributedString initFromData - dont know how to parse %@", docType);
+        return nil;
+    }
+    else if([docType isEqual: NSMacSimpleTextDocumentType]){
+        NSLog(@"NSAttributedString initFromData - dont know how to parse %@", docType);
+        return nil;
+    }
+    else if([docType isEqual: NSOfficeOpenXMLTextDocumentType]){
+        NSLog(@"NSAttributedString initFromData - dont know how to parse %@", docType);
+        return nil;
+    }
+    else if([docType isEqual: NSOpenDocumentTextDocumentType]){
+        NSLog(@"NSAttributedString initFromData - dont know how to parse %@", docType);
+        return nil;
+    }
+    else if([docType isEqual: NSPlainTextDocumentType]){
+        NSLog(@"NSAttributedString initFromData - dont know how to parse %@", docType);
+        return nil;
+    }
+    else if([docType isEqual: NSRTFTextDocumentType]){
+        return [self initWithRTF:data documentAttributes:attributes];
+    }
+    else if([docType isEqual: NSRTFDTextDocumentType]){
+        return [self initWithRTFD:data documentAttributes:attributes];
+    }
+    else if([docType isEqual: NSWebArchiveTextDocumentType]){
+        NSLog(@"NSAttributedString initFromData - dont know how to parse %@", docType);
+        return nil;
+    }
+    else if([docType isEqual: NSWordMLTextDocumentType]){
+        NSLog(@"NSAttributedString initFromData - dont know how to parse %@", docType);
+        return nil;
+    }
+    else {
     return nil;
 }
 
@@ -237,7 +286,9 @@ NSUInteger NSUnderlineByWordMask = 0x8000;
                      error: (NSError **) error
 {
     NSUnimplementedMethod();
-    return nil;
+    NSLog(@"NSAttributedString - initializing from URL");
+    NSData *data = [NSData dataWithContentsOfURL: url];
+    return [self initWithData:data options:options documentAttributes:attributes error:error]; 
 }
 
 #pragma mark -

--- a/AppKit/NSAttributedString.m
+++ b/AppKit/NSAttributedString.m
@@ -27,110 +27,95 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #import <AppKit/NSStringDrawer.h>
 #import <AppKit/NSTextAttachment.h>
 
-NSString *const NSFontAttributeName = @"NSFontAttributeName";
-NSString *const NSParagraphStyleAttributeName =
-        @"NSParagraphStyleAttributeName";
-NSString *const NSForegroundColorAttributeName =
-        @"NSForegroundColorAttributeName";
-NSString *const NSBackgroundColorAttributeName =
-        @"NSBackgroundColorAttributeName";
-NSString *const NSUnderlineStyleAttributeName =
-        @"NSUnderlineStyleAttributeName";
-NSString *const NSUnderlineColorAttributeName =
-        @"NSUnderlineColorAttributeName";
-NSString *const NSAttachmentAttributeName = @"NSAttachmentAttributeName";
-NSString *const NSKernAttributeName = @"NSKernAttributeName";
-NSString *const NSLigatureAttributeName = @"NSLigatureAttributeName";
-NSString *const NSStrikethroughStyleAttributeName =
-        @"NSStrikethroughStyleAttributeName";
-NSString *const NSStrikethroughColorAttributeName =
-        @"NSStrikethroughColorAttributeName";
-NSString *const NSObliquenessAttributeName = @"NSObliquenessAttributeName";
-NSString *const NSStrokeWidthAttributeName = @"NSStrokeWidthAttributeName";
-NSString *const NSStrokeColorAttributeName = @"NSStrokeColorAttributeName";
-NSString *const NSBaselineOffsetAttributeName =
-        @"NSBaselineOffsetAttributeName";
-NSString *const NSSuperscriptAttributeName = @"NSSuperscriptAttributeName";
-NSString *const NSLinkAttributeName = @"NSLinkAttributeName";
-NSString *const NSShadowAttributeName = @"NSShadowAttributeName";
-NSString *const NSExpansionAttributeName = @"NSExpansionAttributeName";
-NSString *const NSCursorAttributeName = @"NSCursorAttributeName";
-NSString *const NSToolTipAttributeName = @"NSToolTipAttributeName";
-NSString *const NSSpellingStateAttributeName =
-        @"NSSpellingStateAttributeName"; // temporary attribute
+NSAttributedStringKey NSFontAttributeName = @"NSFontAttributeName";
+NSAttributedStringKey NSParagraphStyleAttributeName = @"NSParagraphStyleAttributeName";
+NSAttributedStringKey NSForegroundColorAttributeName = @"NSForegroundColorAttributeName";
+NSAttributedStringKey NSBackgroundColorAttributeName = @"NSBackgroundColorAttributeName";
+NSAttributedStringKey NSUnderlineStyleAttributeName = @"NSUnderlineStyleAttributeName";
+NSAttributedStringKey NSUnderlineColorAttributeName = @"NSUnderlineColorAttributeName";
+NSAttributedStringKey NSAttachmentAttributeName = @"NSAttachmentAttributeName";
+NSAttributedStringKey NSKernAttributeName = @"NSKernAttributeName";
+NSAttributedStringKey NSLigatureAttributeName = @"NSLigatureAttributeName";
+NSAttributedStringKey NSStrikethroughStyleAttributeName = @"NSStrikethroughStyleAttributeName";
+NSAttributedStringKey NSStrikethroughColorAttributeName = @"NSStrikethroughColorAttributeName";
+NSAttributedStringKey NSObliquenessAttributeName = @"NSObliquenessAttributeName";
+NSAttributedStringKey NSStrokeWidthAttributeName = @"NSStrokeWidthAttributeName";
+NSAttributedStringKey NSStrokeColorAttributeName = @"NSStrokeColorAttributeName";
+NSAttributedStringKey NSBaselineOffsetAttributeName = @"NSBaselineOffsetAttributeName";
+NSAttributedStringKey NSSuperscriptAttributeName = @"NSSuperscriptAttributeName";
+NSAttributedStringKey NSLinkAttributeName = @"NSLinkAttributeName";
+NSAttributedStringKey NSShadowAttributeName = @"NSShadowAttributeName";
+NSAttributedStringKey NSExpansionAttributeName = @"NSExpansionAttributeName";
+NSAttributedStringKey NSCursorAttributeName = @"NSCursorAttributeName";
+NSAttributedStringKey NSToolTipAttributeName = @"NSToolTipAttributeName";
+NSAttributedStringKey NSSpellingStateAttributeName = @"NSSpellingStateAttributeName"; // temporary attribute
 
-NSString *const NSDocumentTypeDocumentAttribute = @"DocumentType";
-NSString *const NSConvertedDocumentAttribute = @"Converted";
-NSString *const NSFileTypeDocumentAttribute = @"UTI";
-NSString *const NSTitleDocumentAttribute = @"NSTitleDocumentAttribute";
-NSString *const NSCompanyDocumentAttribute = @"NSCompanyDocumentAttribute";
-NSString *const NSCopyrightDocumentAttribute = @"NSCopyrightDocumentAttribute";
-NSString *const NSSubjectDocumentAttribute = @"NSSubjectDocumentAttribute";
-NSString *const NSAuthorDocumentAttribute = @"NSAuthorDocumentAttribute";
-NSString *const NSKeywordsDocumentAttribute = @"NSKeywordsDocumentAttribute";
-NSString *const NSCommentDocumentAttribute = @"NSCommentDocumentAttribute";
-NSString *const NSEditorDocumentAttribute = @"NSEditorDocumentAttribute";
-NSString *const NSCreationTimeDocumentAttribute =
-        @"NSCreationTimeDocumentAttribute";
-NSString *const NSModificationTimeDocumentAttribute =
-        @"NSModificationTimeDocumentAttribute";
-NSString *const NSManagerDocumentAttribute = @"NSManagerDocumentAttribute";
-NSString *const NSCategoryDocumentAttribute = @"NSCategoryDocumentAttribute";
-NSString *const NSAppearanceDocumentAttribute =
-        @"NSAppearanceDocumentAttribute";
-NSString *const NSCharacterEncodingDocumentAttribute = @"CharacterEncoding";
-NSString *const NSDefaultAttributesDocumentAttribute = @"DefaultAttributes";
-NSString *const NSPaperSizeDocumentAttribute = @"PaperSize";
-NSString *const NSLeftMarginDocumentAttribute = @"LeftMargin";
-NSString *const NSRightMarginDocumentAttribute = @"RightMargin";
-NSString *const NSTopMarginDocumentAttribute = @"TopMargin";
-NSString *const NSBottomMarginDocumentAttribute = @"BottomMargin";
-NSString *const NSViewSizeDocumentAttribute = @"ViewSize";
-NSString *const NSViewZoomDocumentAttribute = @"ViewZoom";
-NSString *const NSViewModeDocumentAttribute = @"ViewMode";
-NSString *const NSReadOnlyDocumentAttribute = @"ReadOnly";
-NSString *const NSBackgroundColorDocumentAttribute = @"BackgroundColor";
-NSString *const NSHyphenationFactorDocumentAttribute = @"HyphenationFactor";
-NSString *const NSDefaultTabIntervalDocumentAttribute = @"DefaultTabInterval";
-NSString *const NSTextLayoutSectionsAttribute =
-        @"NSTextLayoutSectionsAttribute";
-NSString *const NSExcludedElementsDocumentAttribute = @"ExcludedElements";
-NSString *const NSTextEncodingNameDocumentAttribute = @"TextEncodingName";
-NSString *const NSPrefixSpacesDocumentAttribute = @"PrefixSpaces";
+NSAttributedStringDocumentAttributeKey NSDocumentTypeDocumentAttribute = @"DocumentType";
+NSAttributedStringDocumentAttributeKey NSConvertedDocumentAttribute = @"Converted";
+NSAttributedStringDocumentAttributeKey NSFileTypeDocumentAttribute = @"UTI";
+NSAttributedStringDocumentAttributeKey NSTitleDocumentAttribute = @"NSTitleDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSCompanyDocumentAttribute = @"NSCompanyDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSCopyrightDocumentAttribute = @"NSCopyrightDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSSubjectDocumentAttribute = @"NSSubjectDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSAuthorDocumentAttribute = @"NSAuthorDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSKeywordsDocumentAttribute = @"NSKeywordsDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSCommentDocumentAttribute = @"NSCommentDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSEditorDocumentAttribute = @"NSEditorDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSCreationTimeDocumentAttribute = @"NSCreationTimeDocumentAttribute";
+NSAttributedStringKey NSModificationTimeDocumentAttribute = @"NSModificationTimeDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSManagerDocumentAttribute = @"NSManagerDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSCategoryDocumentAttribute = @"NSCategoryDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSAppearanceDocumentAttribute = @"NSAppearanceDocumentAttribute";
+NSAttributedStringDocumentAttributeKey NSCharacterEncodingDocumentAttribute = @"CharacterEncoding";
+NSAttributedStringDocumentAttributeKey NSDefaultAttributesDocumentAttribute = @"DefaultAttributes";
+NSAttributedStringDocumentAttributeKey NSPaperSizeDocumentAttribute = @"PaperSize";
+NSAttributedStringDocumentAttributeKey NSLeftMarginDocumentAttribute = @"LeftMargin";
+NSAttributedStringDocumentAttributeKey NSRightMarginDocumentAttribute = @"RightMargin";
+NSAttributedStringDocumentAttributeKey NSTopMarginDocumentAttribute = @"TopMargin";
+NSAttributedStringDocumentAttributeKey NSBottomMarginDocumentAttribute = @"BottomMargin";
+NSAttributedStringDocumentAttributeKey NSViewSizeDocumentAttribute = @"ViewSize";
+NSAttributedStringDocumentAttributeKey NSViewZoomDocumentAttribute = @"ViewZoom";
+NSAttributedStringDocumentAttributeKey NSViewModeDocumentAttribute = @"ViewMode";
+NSAttributedStringDocumentAttributeKey NSReadOnlyDocumentAttribute = @"ReadOnly";
+NSAttributedStringDocumentAttributeKey NSBackgroundColorDocumentAttribute = @"BackgroundColor";
+NSAttributedStringDocumentAttributeKey NSHyphenationFactorDocumentAttribute = @"HyphenationFactor";
+NSAttributedStringDocumentAttributeKey NSDefaultTabIntervalDocumentAttribute = @"DefaultTabInterval";
+NSAttributedStringDocumentAttributeKey NSTextLayoutSectionsAttribute = @"NSTextLayoutSectionsAttribute";
+NSAttributedStringDocumentAttributeKey NSExcludedElementsDocumentAttribute = @"ExcludedElements";
+NSAttributedStringDocumentAttributeKey NSTextEncodingNameDocumentAttribute = @"TextEncodingName";
+NSAttributedStringDocumentAttributeKey NSPrefixSpacesDocumentAttribute = @"PrefixSpaces";
+NSAttributedStringDocumentAttributeKey NSCocoaVersionDocumentAttribute = @"NSCocoaVersionDocumentAttribute";
 
-NSString *const NSDocumentTypeDocumentOption = @"DocumentType";
-NSString *const NSDefaultAttributesDocumentOption = @"DefaultAttributes";
-NSString *const NSCharacterEncodingDocumentOption = @"CharacterEncoding";
-NSString *const NSTextEncodingNameDocumentOption = @"TextEncodingName";
-NSString *const NSBaseURLDocumentOption = @"BaseURL";
-NSString *const NSTimeoutDocumentOption = @"Timeout";
-NSString *const NSWebPreferencesDocumentOption = @"WebPreferences";
-NSString *const NSWebResourceLoadDelegateDocumentOption =
-        @"WebResourceLoadDelegate";
-NSString *const NSTextSizeMultiplierDocumentOption = @"TextSizeMultiplier";
-NSString *const NSFileTypeDocumentOption = @"UTI";
+NSAttributedStringDocumentReadingOptionKey NSDocumentTypeDocumentOption = @"DocumentType";
+NSAttributedStringDocumentReadingOptionKey NSDefaultAttributesDocumentOption = @"DefaultAttributes";
+NSAttributedStringDocumentReadingOptionKey NSCharacterEncodingDocumentOption = @"CharacterEncoding";
+NSAttributedStringDocumentReadingOptionKey NSTextEncodingNameDocumentOption = @"TextEncodingName";
+NSAttributedStringDocumentReadingOptionKey NSBaseURLDocumentOption = @"BaseURL";
+NSAttributedStringDocumentReadingOptionKey NSTimeoutDocumentOption = @"Timeout";
+NSAttributedStringDocumentReadingOptionKey NSWebPreferencesDocumentOption = @"WebPreferences";
+NSAttributedStringDocumentReadingOptionKey NSWebResourceLoadDelegateDocumentOption = @"WebResourceLoadDelegate";
+NSAttributedStringDocumentReadingOptionKey NSTextSizeMultiplierDocumentOption = @"TextSizeMultiplier";
+NSAttributedStringDocumentReadingOptionKey NSFileTypeDocumentOption = @"UTI";
 
-NSString *const NSPlainTextDocumentType = @"NSPlainText";
-NSString *const NSRTFTextDocumentType = @"NSRTF";
-NSString *const NSRTFDTextDocumentType = @"NSRTFD";
-NSString *const NSHTMLTextDocumentType = @"NSHTML";
-NSString *const NSMacSimpleTextDocumentType = @"NSMacSimpleText";
-NSString *const NSDocFormatTextDocumentType = @"NSDocFormat";
-NSString *const NSWordMLTextDocumentType = @"NSWordML";
-NSString *const NSWebArchiveTextDocumentType = @"NSWebArchive";
-NSString *const NSOfficeOpenXMLTextDocumentType = @"NSOfficeOpenXML";
-NSString *const NSOpenDocumentTextDocumentType = @"NSOpenDocument";
+NSAttributedStringDocumentType NSPlainTextDocumentType = @"NSPlainText";
+NSAttributedStringDocumentType NSRTFTextDocumentType = @"NSRTF";
+NSAttributedStringDocumentType NSRTFDTextDocumentType = @"NSRTFD";
+NSAttributedStringDocumentType NSHTMLTextDocumentType = @"NSHTML";
+NSAttributedStringDocumentType NSMacSimpleTextDocumentType = @"NSMacSimpleText";
+NSAttributedStringDocumentType NSDocFormatTextDocumentType = @"NSDocFormat";
+NSAttributedStringDocumentType NSWordMLTextDocumentType = @"NSWordML";
+NSAttributedStringDocumentType NSWebArchiveTextDocumentType = @"NSWebArchive";
+NSAttributedStringDocumentType NSOfficeOpenXMLTextDocumentType = @"NSOfficeOpenXML";
+NSAttributedStringDocumentType NSOpenDocumentTextDocumentType = @"NSOpenDocument";
 
-NSString *const NSTextLayoutSectionOrientation =
-        @"NSTextLayoutSectionOrientation";
-NSString *const NSTextLayoutSectionRange = @"NSTextLayoutSectionRange";
+NSTextLayoutSectionKey NSTextLayoutSectionOrientation = @"NSTextLayoutSectionOrientation";
+NSTextLayoutSectionKey NSTextLayoutSectionRange = @"NSTextLayoutSectionRange";
 
-NSString *const NSCharacterShapeAttributeName = @"NSCharacterShape";
-NSString *const NSUsesScreenFontsDocumentAttribute = @"UsesScreenFonts";
+NSAttributedStringKey NSCharacterShapeAttributeName = @"NSCharacterShape";
+NSAttributedStringKey NSUsesScreenFontsDocumentAttribute = @"UsesScreenFonts";
 
-NSString *const NSTextEffectAttributeName = @"NSTextEffect";
+const NSAttributedStringKey NSTextEffectAttributeName = @"NSTextEffect";
 NSAttributedStringKey NSWritingDirectionAttributeName = @"NSWritingDirectionAttribute";
-NSString *const NSCocoaVersionDocumentAttribute  = @"NSCocoaVersionDocumentAttribute";
 
 NSUInteger NSUnderlineStrikethroughMask = 0x4000;
 NSUInteger NSUnderlineByWordMask = 0x8000;
@@ -159,15 +144,48 @@ NSUInteger NSUnderlineByWordMask = 0x8000;
                      error: (NSError **) error
 {
     NSUnimplementedMethod();
-    NSString *docType = [options objectForKey:@"NSDocumentTypeDocumentAttribute"];
-    
+    NSString *docType = [options objectForKey:NSDocumentTypeDocumentAttribute];
+   
+    //Infer the document format if not provided
     if(docType == nil){
-        NSLog(@"NSAttributedString initFromData - inferring document type");
-        //TODO: infer document type (assume RTF for now)
-        docType = NSRTFTextDocumentType;
+        //Extract a prefix from the document to identify the type
+        //FIXME: use 64 bit ready types and check encoding
+        char prefix[14];
+        NSUInteger dataLength = [data length];
+        
+        if(dataLength < sizeof(prefix))
+        {
+            [data getBytes: prefix length: dataLength];
+            prefix[dataLength] = 0;
+        }
+        else
+        {
+            [data getBytes: prefix length: sizeof(prefix)];
+        }
+
+        //Use the prefix to determine the document format
+        // FIXME extend the list
+        if (strncmp(prefix, "{\\rtf", 5) == 0)
+        {
+            docType = NSRTFTextDocumentType;
+        }
+        else if (strncasecmp(prefix, "<!doctype html", 14) == 0 ||
+                 strncasecmp(prefix, "<head", 5) == 0 ||
+                 strncasecmp(prefix, "<title", 6) == 0 ||
+                 strncasecmp(prefix, "<html", 5) == 0 ||
+                 strncmp(prefix, "<!--", 4) == 0 ||
+                 strncasecmp(prefix, "<h1", 3) == 0)
+        {
+            docType = NSHTMLTextDocumentType;
+        }
+        else
+        {
+            docType = NSPlainTextDocumentType;
+        }
     }
 
     //Read the document based on its type
+    //TODO: Implement reading for all types
     if([docType isEqual: NSDocFormatTextDocumentType]){
         return nil;
     }
@@ -192,10 +210,11 @@ NSUInteger NSUnderlineByWordMask = 0x8000;
         return nil;
     }
     else if([docType isEqual: NSRTFTextDocumentType]){
-        return [self initWithRTF:data documentAttributes:attributes];
+        return [self initWithRTF: data documentAttributes: attributes];
     }
     else if([docType isEqual: NSRTFDTextDocumentType]){
-        return [self initWithRTFD:data documentAttributes:attributes];
+        NSLog(@"NSAttributedString initFromData - dont know how to parse %@", docType);
+        return nil;
     }
     else if([docType isEqual: NSWebArchiveTextDocumentType]){
         NSLog(@"NSAttributedString initFromData - dont know how to parse %@", docType);
@@ -253,7 +272,8 @@ NSUInteger NSUnderlineByWordMask = 0x8000;
 }
 
 - initWithRTF: (NSData *) rtf documentAttributes: (NSDictionary **) attributes {
-    NSLog(@"NSAttributedString - initializing from RTF");
+    *attributes = [NSDictionary dictionaryWithObject: NSRTFTextDocumentType 
+                                              forKey: NSDocumentTypeDocumentAttribute];
     NSAttributedString *string =
             [NSRichTextReader attributedStringWithData: rtf];
     if (string == nil) {
@@ -287,9 +307,8 @@ NSUInteger NSUnderlineByWordMask = 0x8000;
         documentAttributes: (NSDictionary **) attributes
                      error: (NSError **) error
 {
-    NSLog(@"NSAttributedString - initializing from URL");
     NSData *data = [NSData dataWithContentsOfURL: url];
-    return [self initWithData:data options:options documentAttributes:attributes error:error]; 
+    return [self initWithData: data options: options documentAttributes: attributes error: error]; 
 }
 
 #pragma mark -

--- a/AppKit/NSAttributedString.m
+++ b/AppKit/NSAttributedString.m
@@ -159,7 +159,7 @@ NSUInteger NSUnderlineByWordMask = 0x8000;
                      error: (NSError **) error
 {
     NSUnimplementedMethod();
-    NSString *docType = [options objectForKey:NSDocumentTypeDocumentAttribute];
+    NSString *docType = [options objectForKey:@"NSDocumentTypeDocumentAttribute"];
     
     if(docType == nil){
         NSLog(@"NSAttributedString initFromData - inferring document type");
@@ -207,6 +207,7 @@ NSUInteger NSUnderlineByWordMask = 0x8000;
     }
     else {
     return nil;
+    }
 }
 
 - initWithDocFormat: (NSData *) werd
@@ -252,6 +253,7 @@ NSUInteger NSUnderlineByWordMask = 0x8000;
 }
 
 - initWithRTF: (NSData *) rtf documentAttributes: (NSDictionary **) attributes {
+    NSLog(@"NSAttributedString - initializing from RTF");
     NSAttributedString *string =
             [NSRichTextReader attributedStringWithData: rtf];
     if (string == nil) {
@@ -285,7 +287,6 @@ NSUInteger NSUnderlineByWordMask = 0x8000;
         documentAttributes: (NSDictionary **) attributes
                      error: (NSError **) error
 {
-    NSUnimplementedMethod();
     NSLog(@"NSAttributedString - initializing from URL");
     NSData *data = [NSData dataWithContentsOfURL: url];
     return [self initWithData:data options:options documentAttributes:attributes error:error]; 

--- a/AppKit/NSDocument.m
+++ b/AppKit/NSDocument.m
@@ -426,6 +426,10 @@ static int untitled_document_number = 0;
     case NSChangeAutosaved:
         NSUnimplementedMethod();
         break;
+
+    case NSChangeRedone:
+        _changeCount++; //Opposite of Undo - this may be wrong
+        break;
     }
 
     BOOL edited = [self isDocumentEdited];
@@ -467,6 +471,7 @@ static int untitled_document_number = 0;
         if ([self _isSelectorOverridden: @selector(readFromFile:ofType:)]) {
             return [self readFromFile: [url path] ofType: type];
         } else {
+
             NSFileWrapper *fileWrapper = [[[NSFileWrapper alloc]
                     initWithPath: [url path]] autorelease];
 
@@ -695,8 +700,8 @@ static int untitled_document_number = 0;
 
 #if 0
     // setAllowedFileTypes: is unimplemented - so don't call it.
-	NSArray* writableTypes = [self writableTypesForSaveOperation: operation];
-	[savePanel setAllowedFileTypes: writableTypes];
+    NSArray* writableTypes = [self writableTypesForSaveOperation: operation];
+    [savePanel setAllowedFileTypes: writableTypes];
 #endif
 
     if ([self prepareSavePanel: savePanel] == NO) {
@@ -1197,9 +1202,8 @@ static int untitled_document_number = 0;
     return self;
 }
 
-- initWithContentsOfURL: (NSURL *) url ofType: (NSString *) type {
+- (id) initWithContentsOfURL: (NSURL *) url ofType: (NSString *) type {
     NSError *error;
-
     [self init];
 
     error = nil;
@@ -1222,6 +1226,7 @@ static int untitled_document_number = 0;
 
     return self;
 }
+
 
 - (BOOL) loadDataRepresentation: (NSData *) data ofType: (NSString *) type {
     [NSException raise: NSInternalInconsistencyException
@@ -1505,6 +1510,20 @@ static int untitled_document_number = 0;
 - (void) performSynchronousFileAccessUsingBlock: (void (^)(void)) block {
     // FIXME: this is just a stub for now that performs no synchronization
     block();
+}
+
+- (void) saveToURL: (NSURL *) url
+            ofType: (NSString *) typeName
+  forSaveOperation: (NSSaveOperationType) saveOperation
+ completionHandler: (void (^)(NSError *errorOrNil)) completionHandler
+ {
+    NSUnimplementedMethod();
+}
+
+- (void) autosaveWithImplicitCancellability: (BOOL) autosavingIsImplicitlyCancellable
+                          completionHandler: (void (^)(NSError *errorOrNil)) completionHandler
+{
+    NSUnimplementedMethod();
 }
 
 @end

--- a/AppKit/NSDocumentController.m
+++ b/AppKit/NSDocumentController.m
@@ -305,12 +305,10 @@ static NSDocumentController *shared = nil;
         //TODO: move below code to documentClassForType
         for(NSDictionary *type in _fileTypes){
             for(NSString *contentType in [type objectForKey:@"LSItemContentTypes"]){
-                return [type objectForKey:@"CFBundleTypeName"];
+                if([contentType isEqual: UTI])
+                    return [type objectForKey:@"CFBundleTypeName"];
             }
         }
-    }
-    else{
-        //TODO:Handle Error Here
     }
     return nil;
 }
@@ -330,13 +328,11 @@ static NSDocumentController *shared = nil;
                           error: (NSError **) error
 {
     id result;
-    NSLog(@"DocController - making %@ from URL", type);
     Class class = [self documentClassForType: type];
 
-    NSLog(@"DocController - initializing Document");
     result = [[[class alloc] initWithContentsOfURL: url
-                                            ofType: type ] autorelease];
-    NSLog(@"NSDocController - made from URL");
+                                            ofType: type] autorelease];
+
     return result;
 }
 
@@ -422,7 +418,6 @@ static NSDocumentController *shared = nil;
 
 - openUntitledDocumentAndDisplay: (BOOL) display error: (NSError **) error {
     NSString *type = [self defaultType];
-
     /* Cocoa documentation says:
          "For backward binary compatibility with Mac OS X v10.3 and earlier,
           the default implementation of this method instead invokes

--- a/AppKit/NSDocumentController.m
+++ b/AppKit/NSDocumentController.m
@@ -185,8 +185,7 @@ static NSDocumentController *shared = nil;
         }
     }
 
-    return (result == nil) ? [_NSUnsupportedDocument class]
-                           : NSClassFromString(result);
+    return (result == nil) ? nil : NSClassFromString(result);
 }
 
 - (NSArray *) fileExtensionsFromType: (NSString *) type {

--- a/AppKit/NSMutableAttributedString.m
+++ b/AppKit/NSMutableAttributedString.m
@@ -203,4 +203,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     [self endEditing];
 }
 
+- (BOOL) readFromURL:(NSURL *)url 
+             options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)opts 
+  documentAttributes:(NSDictionary<NSAttributedStringDocumentAttributeKey, id> * _Nullable *)dict 
+               error:(NSError * _Nullable *)error {
+    NSAttributedString *str = [NSAttributedString alloc]; 
+    [str initWithURL:url options:opts documentAttributes:dict error:error];
+    //[self setAttributedString:str];
+    NSLog(@"NSMutableAttributedString readFromURL: - hopefully finished reading!");
+    return true;
+}
+
 @end

--- a/AppKit/NSMutableAttributedString.m
+++ b/AppKit/NSMutableAttributedString.m
@@ -203,14 +203,22 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     [self endEditing];
 }
 
-- (BOOL) readFromURL:(NSURL *)url 
-             options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)opts 
-  documentAttributes:(NSDictionary<NSAttributedStringDocumentAttributeKey, id> * _Nullable *)dict 
-               error:(NSError * _Nullable *)error {
-    NSAttributedString *str = [NSAttributedString alloc]; 
-    [str initWithURL:url options:opts documentAttributes:dict error:error];
-    //[self setAttributedString:str];
-    NSLog(@"NSMutableAttributedString readFromURL: - hopefully finished reading!");
-    return true;
+- (BOOL) readFromURL: (NSURL *) url
+             options: (NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *) opts
+  documentAttributes: (NSDictionary<NSAttributedStringDocumentAttributeKey, id> *_Nullable *) dict
+               error: (NSError *_Nullable *) error
+{
+    NSAttributedString *str = [NSAttributedString alloc];
+    str = [str initWithURL: url
+                   options: opts
+        documentAttributes: dict
+                     error: error];
+    if (str == nil) {
+        return NO;
+    }
+    [self setAttributedString: str];
+    [str release];
+    return YES;
 }
+
 @end

--- a/AppKit/NSMutableAttributedString.m
+++ b/AppKit/NSMutableAttributedString.m
@@ -213,5 +213,4 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     NSLog(@"NSMutableAttributedString readFromURL: - hopefully finished reading!");
     return true;
 }
-
 @end

--- a/AppKit/NSMutableParagraphStyle.m
+++ b/AppKit/NSMutableParagraphStyle.m
@@ -128,17 +128,29 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 }
 
 - (void) setTabStops: (NSArray *) tabStops {
-    tabStops = [tabStops copy];
-    [_tabStops release];
-    _tabStops = tabStops;
+    if (tabStops != _tabStops) {
+        [_tabStops removeAllObjects];
+        [_tabStops addObjectsFromArray: tabStops];
+        [_tabStops sortUsingSelector: @selector(compare:)];
+    }
 }
 
-- (void) addTabStop:(NSTextTab *) tabStop {
-    //NSUnimplementedMethod();
+- (void) addTabStop: (NSTextTab *) tabStop {
+    NSUInteger index = [_tabStops
+            indexOfObjectPassingTest: ^BOOL(NSTextTab *other, NSUInteger id,
+                                            BOOL *stop) {
+              return [other compare: tabStop] == NSOrderedAscending;
+            }];
+
+    if (index == NSNotFound) {
+        [_tabStops insertObject: tabStop atIndex: 0];
+    } else {
+        [_tabStops insertObject: tabStop atIndex: index];
+    }
 }
 
-- (void) removeTabStop:(NSTextTab *) tabStop {
-    //NSUnimplementedMethod();
+- (void) removeTabStop: (NSTextTab *) tabStop {
+    [_tabStops removeObject: tabStop];
 }
 
 - (void) setHyphenationFactor: (float) factor {

--- a/AppKit/NSMutableParagraphStyle.m
+++ b/AppKit/NSMutableParagraphStyle.m
@@ -133,6 +133,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     _tabStops = tabStops;
 }
 
+- (void) addTabStop:(NSTextTab *) tabStop {
+    //NSUnimplementedMethod();
+}
+
+- (void) removeTabStop:(NSTextTab *) tabStop {
+    //NSUnimplementedMethod();
+}
+
 - (void) setHyphenationFactor: (float) factor {
     _hyphenationFactor = factor;
 }

--- a/AppKit/NSParagraphStyle.m
+++ b/AppKit/NSParagraphStyle.m
@@ -34,6 +34,11 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     return shared;
 }
 
++ (NSWritingDirection)defaultWritingDirectionForLanguage:(NSString *)languageName {
+    NSUnimplementedMethod();
+    return NSWritingDirectionNatural;
+}
+
 + (NSArray *) _defaultTabStops {
     static NSArray *shared = nil;
 

--- a/AppKit/NSParagraphStyle.m
+++ b/AppKit/NSParagraphStyle.m
@@ -34,7 +34,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     return shared;
 }
 
-+ (NSWritingDirection)defaultWritingDirectionForLanguage:(NSString *)languageName {
++ (NSWritingDirection) defaultWritingDirectionForLanguage: (NSString *) languageName {
     NSUnimplementedMethod();
     return NSWritingDirectionNatural;
 }
@@ -74,7 +74,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     _lineHeightMultiple = 0;
     _lineSpacing = 0;
     _defaultTabInterval = 0;
-    _tabStops = [[[self class] _defaultTabStops] retain];
+    _tabStops = [[[self class] _defaultTabStops] mutableCopy];
     _hyphenationFactor = 0;
     _tighteningFactorForTruncation = 0;
 }

--- a/AppKit/NSScrollView.m
+++ b/AppKit/NSScrollView.m
@@ -86,14 +86,18 @@ static Class _rulerViewClass = nil;
     return contentSize;
 }
 
-+ (NSSize)frameSizeForContentSize:(NSSize)cSize 
-          horizontalScrollerClass:(Class)horizontalScrollerClass 
-            verticalScrollerClass:(Class)verticalScrollerClass 
-                       borderType:(NSBorderType)type 
-                      controlSize:(NSControlSize)controlSize 
-                    scrollerStyle:(NSScrollerStyle)scrollerStyle
++ (NSSize) frameSizeForContentSize: (NSSize) cSize
+           horizontalScrollerClass: (Class) horizontalScrollerClass
+             verticalScrollerClass: (Class) verticalScrollerClass
+                        borderType: (NSBorderType) type
+                       controlSize: (NSControlSize) controlSize
+                     scrollerStyle: (NSScrollerStyle) scrollerStyle
 {
     NSUnimplementedMethod();
+    return [self frameSizeForContentSize: cSize
+                   hasHorizontalScroller: YES
+                     hasVerticalScroller: YES
+                              borderType: type];
 }
 
 + (NSSize) contentSizeForFrameSize: (NSSize) frameSize
@@ -130,12 +134,12 @@ static Class _rulerViewClass = nil;
     return frameSize;
 }
 
-+ (NSSize)contentSizeForFrameSize:(NSSize)fSize 
-          horizontalScrollerClass:(Class)horizontalScrollerClass 
-            verticalScrollerClass:(Class)verticalScrollerClass 
-                       borderType:(NSBorderType)type 
-                      controlSize:(NSControlSize)controlSize 
-                    scrollerStyle:(NSScrollerStyle)scrollerStyle
++ (NSSize) contentSizeForFrameSize: (NSSize) fSize
+           horizontalScrollerClass: (Class) horizontalScrollerClass
+             verticalScrollerClass: (Class) verticalScrollerClass
+                        borderType: (NSBorderType) type
+                       controlSize: (NSControlSize) controlSize
+                     scrollerStyle: (NSScrollerStyle) scrollerStyle
 {
     NSUnimplementedMethod();
 }
@@ -816,23 +820,35 @@ static Class _rulerViewClass = nil;
 }
 
 - (void) setMagnification: (CGFloat) value {
+    if (value == _magnification)
+        return;
+
     _magnification = value;
-    NSUnimplementedMethod();
+
+    if (_magnification < _minMagnification)
+        _magnification = _minMagnification;
+    if (_magnification < _maxMagnification)
+        _magnification = _maxMagnification;
+
+    // TODO: calculate new bounds and call setBounds
 }
 
 - (void) setMinMagnification: (CGFloat) value {
     _minMagnification = value;
-    NSUnimplementedMethod();
+
+    if (_minMagnification > _magnification)
+        [self setMagnification: value];
 }
 
 - (void) setMaxMagnification: (CGFloat) value {
     _maxMagnification = value;
-    NSUnimplementedMethod();
+
+    if (_maxMagnification < _magnification)
+        [self setMagnification: value];
 }
 
 - (void) setAllowsMagnification: (BOOL) value {
     _allowsMagnification = value;
-    NSUnimplementedMethod();
 }
 
 - (void) tile {

--- a/AppKit/NSScrollView.m
+++ b/AppKit/NSScrollView.m
@@ -86,6 +86,16 @@ static Class _rulerViewClass = nil;
     return contentSize;
 }
 
++ (NSSize)frameSizeForContentSize:(NSSize)cSize 
+          horizontalScrollerClass:(Class)horizontalScrollerClass 
+            verticalScrollerClass:(Class)verticalScrollerClass 
+                       borderType:(NSBorderType)type 
+                      controlSize:(NSControlSize)controlSize 
+                    scrollerStyle:(NSScrollerStyle)scrollerStyle
+{
+    NSUnimplementedMethod();
+}
+
 + (NSSize) contentSizeForFrameSize: (NSSize) frameSize
              hasHorizontalScroller: (BOOL) hasHorizontalScroller
                hasVerticalScroller: (BOOL) hasVerticalScroller
@@ -118,6 +128,16 @@ static Class _rulerViewClass = nil;
     }
 
     return frameSize;
+}
+
++ (NSSize)contentSizeForFrameSize:(NSSize)fSize 
+          horizontalScrollerClass:(Class)horizontalScrollerClass 
+            verticalScrollerClass:(Class)verticalScrollerClass 
+                       borderType:(NSBorderType)type 
+                      controlSize:(NSControlSize)controlSize 
+                    scrollerStyle:(NSScrollerStyle)scrollerStyle
+{
+    NSUnimplementedMethod();
 }
 
 + (void) setRulerViewClass: (Class) class {
@@ -614,6 +634,22 @@ static Class _rulerViewClass = nil;
     return _documentCursor;
 }
 
+- (CGFloat) magnification {
+    return _magnification;
+}
+
+- (CGFloat) minMagnification {
+    return _minMagnification;
+}
+
+- (CGFloat) maxMagnification {
+    return _maxMagnification;
+}
+
+- (BOOL) allowsMagnification {
+    return _allowsMagnification;
+}
+
 - (void) setDocumentView: (NSView *) view {
     [_clipView setDocumentView: view];
     [self reflectScrolledClipView: _clipView];
@@ -777,6 +813,26 @@ static Class _rulerViewClass = nil;
 - (void) setAutohidesScrollers: (BOOL) value {
     _autohidesScrollers = value;
     // FIXME: tile or hide/show scrollers?
+}
+
+- (void) setMagnification: (CGFloat) value {
+    _magnification = value;
+    NSUnimplementedMethod();
+}
+
+- (void) setMinMagnification: (CGFloat) value {
+    _minMagnification = value;
+    NSUnimplementedMethod();
+}
+
+- (void) setMaxMagnification: (CGFloat) value {
+    _maxMagnification = value;
+    NSUnimplementedMethod();
+}
+
+- (void) setAllowsMagnification: (BOOL) value {
+    _allowsMagnification = value;
+    NSUnimplementedMethod();
 }
 
 - (void) tile {

--- a/AppKit/NSScroller.m
+++ b/AppKit/NSScroller.m
@@ -34,6 +34,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     return [[NSDisplay currentDisplay] scrollerWidth];
 }
 
++ (NSScrollerStyle) preferredScrollerStyle {
+    NSUnimplementedMethod();
+}
 /* OS X has a global default "AppleScrollBarVariant" with the values: Single,
  DoubleMin, DoubleMax, and DoubleBoth This controls the default position of the
  scroller. This should be controlling the positioning.
@@ -141,6 +144,11 @@ static NSAppleScrollBarVariant appleScrollBarVariant(NSScroller *self) {
     return _controlSize;
 }
 
+- (NSScrollerStyle) scrollerStyle {
+    return _scrollerStyle;
+}
+
+
 - (void) setFloatValue: (float) zeroToOneValue
         knobProportion: (CGFloat) zeroToOneKnob
 {
@@ -183,6 +191,10 @@ static NSAppleScrollBarVariant appleScrollBarVariant(NSScroller *self) {
 - (void) setControlSize: (NSControlSize) value {
     _controlSize = value;
     [self setNeedsDisplay: YES];
+}
+
+- (void) setScrollerStyle: (NSScrollerStyle) style {
+    _scrollerStyle = style;
 }
 
 - (NSRect) frameOfDecrementPage {

--- a/AppKit/NSTextView.subproj/NSLayoutManager.m
+++ b/AppKit/NSTextView.subproj/NSLayoutManager.m
@@ -177,6 +177,8 @@ static inline NSGlyphFragment *fragmentAtGlyphIndex(NSLayoutManager *self,
 }
 
 - (NSTextView *) firstTextView {
+    if([_textContainers count] < 1)
+            return nil;
     return [[_textContainers objectAtIndex: 0] textView];
 }
 
@@ -724,6 +726,11 @@ static inline NSGlyphFragment *fragmentAtGlyphIndex(NSLayoutManager *self,
 
 - (NSTextContainer *) extraLineFragmentTextContainer {
     return _extraLineFragmentTextContainer;
+}
+
+- (BOOL) allowsNonContiguousLayout {
+    NSUnimplementedMethod();
+    return _allowsNonContiguousLayout;
 }
 
 - (void) setTextContainer: (NSTextContainer *) container
@@ -2908,5 +2915,10 @@ static inline void _appendRectToCache(NSLayoutManager *self, NSRect rect) {
                                    enabled: (BOOL) isEnabled
 {
     return nil;
+}
+
+- (void) setAllowsNonContiguousLayout: (BOOL) value {
+    _allowsNonContiguousLayout = value;
+    NSUnimplementedMethod();
 }
 @end

--- a/AppKit/NSTextView.subproj/NSTextContainer.m
+++ b/AppKit/NSTextView.subproj/NSTextContainer.m
@@ -189,6 +189,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 - (void) setLayoutManager: (NSLayoutManager *) layoutManager {
     _layoutManager = layoutManager;
+    [_textView _setTextStorage: [_layoutManager textStorage]];
 }
 
 - (void) replaceLayoutManager: (NSLayoutManager *) layoutManager {

--- a/AppKit/NSTextView.subproj/NSTextTab.m
+++ b/AppKit/NSTextView.subproj/NSTextTab.m
@@ -136,4 +136,20 @@ NSString *NSTabColumnTerminatorsAttributeName =
     return self.location == other.location &&
            self.tabStopType == other.tabStopType;
 }
+
+- (NSComparisonResult) compare: (id) anObject {
+    CGFloat loc;
+
+    if (anObject == self)
+        return NSOrderedSame;
+    if (anObject == nil || ![anObject isKindOfClass: [self class]])
+        return NSOrderedAscending;
+    loc = ((NSTextTab *) anObject)->_location;
+    if (_location < loc)
+        return NSOrderedAscending;
+    else if (_location > loc)
+        return NSOrderedDescending;
+    else
+        return NSOrderedSame;
+}
 @end

--- a/AppKit/NSTextView.subproj/NSTextView.m
+++ b/AppKit/NSTextView.subproj/NSTextView.m
@@ -164,6 +164,7 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
     [_typingAttributes release];
     _typingAttributes = typingAttributes;
 
+    [_defaultParagraphStyle release];
     if ([typingAttributes objectForKey: NSParagraphStyleAttributeName]) {
         _defaultParagraphStyle = [[typingAttributes
                 objectForKey: NSParagraphStyleAttributeName] copy];

--- a/AppKit/NSTextView.subproj/NSTextView.m
+++ b/AppKit/NSTextView.subproj/NSTextView.m
@@ -3979,7 +3979,7 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
 - (id) replacementObjectForKeyedArchiver {
     NSUnimplementedMethod();
     return self;
-
+}
 - (NSTextLayoutOrientation) layoutOrientation {
     NSUnimplementedMethod();
     return _layoutOrientation;

--- a/AppKit/NSTextView.subproj/NSTextView.m
+++ b/AppKit/NSTextView.subproj/NSTextView.m
@@ -3630,6 +3630,22 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
     NSUnimplementedMethod();
 }
 
+- (BOOL) smartInsertDeleteEnabled {
+    return _smartInsertDeleteEnabled;
+}
+
+- (void) setSmartInsertDeleteEnabled: (BOOL) boolForKey {
+    _smartInsertDeleteEnabled = boolForKey;
+}
+
+- (BOOL) allowsDocumentBackgroundColorChange {
+    return _allowsDocumentBackgroundColorChange;
+}
+
+- (void) setAllowsDocumentBackgroundColorChange: (BOOL) value {
+    _allowsDocumentBackgroundColorChange = value;
+}
+
 - (void) setSpellingState: (NSInteger) value range: (NSRange) characterRange {
     [[self layoutManager]
             addTemporaryAttribute: NSSpellingStateAttributeName
@@ -3956,6 +3972,35 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
 - (id) replacementObjectForKeyedArchiver {
     NSUnimplementedMethod();
     return self;
+
+- (NSTextLayoutOrientation) layoutOrientation {
+    NSUnimplementedMethod();
+    return _layoutOrientation;
+}
+
+- (void)setLayoutOrientation:(NSTextLayoutOrientation)orientation {
+    _layoutOrientation = orientation;
+    NSUnimplementedMethod();
+}
+
+- (BOOL) usesFindBar {
+    NSUnimplementedMethod();
+    return _usesFindBar;
+}
+
+- (void) setUsesFindBar: (BOOL) value {
+    NSUnimplementedMethod();
+    _usesFindBar = value;
+}
+
+- (BOOL) isIncrementalSearchingEnabled {
+    NSUnimplementedMethod();
+    return _incrementalSearchingEnabled;
+}
+
+- (void) setIncrementalSearchingEnabled: (BOOL) value {
+    NSUnimplementedMethod();
+    _incrementalSearchingEnabled = value;
 }
 
 @end

--- a/AppKit/NSTextView.subproj/NSTextView.m
+++ b/AppKit/NSTextView.subproj/NSTextView.m
@@ -143,6 +143,36 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
     NSUnimplementedMethod();
 }
 
+- (void) _setTextStorage: (NSTextStorage *) storage {
+    if (_ownsTextStorage)
+        [_textStorage release];
+
+    _textStorage = storage;
+    _ownsTextStorage = NO;
+
+    NSMutableDictionary *typingAttributes =
+            [[_textStorage attributesAtIndex: 0
+                              effectiveRange: NULL] mutableCopy];
+    if (![typingAttributes objectForKey: NSFontAttributeName]) {
+        [typingAttributes setObject: _font forKey: NSFontAttributeName];
+    }
+    if (![typingAttributes objectForKey: NSForegroundColorAttributeName]) {
+        [typingAttributes setObject: _textColor
+                             forKey: NSForegroundColorAttributeName];
+    }
+
+    [_typingAttributes release];
+    _typingAttributes = typingAttributes;
+
+    if ([typingAttributes objectForKey: NSParagraphStyleAttributeName]) {
+        _defaultParagraphStyle = [[typingAttributes
+                objectForKey: NSParagraphStyleAttributeName] copy];
+    } else {
+        _defaultParagraphStyle =
+                [[NSParagraphStyle defaultParagraphStyle] copy];
+    }
+}
+
 - initWithCoder: (NSCoder *) coder {
     [super initWithCoder: coder];
 
@@ -240,8 +270,6 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
 - initWithFrame: (NSRect) frame textContainer: (NSTextContainer *) container {
     [super initWithFrame: frame];
 
-    _textStorage = [[container layoutManager] textStorage];
-    _ownsTextStorage = NO;
     _textContainer = [container retain];
     [_textContainer setTextView: self];
     _textContainerInset = NSMakeSize(0, 0);
@@ -263,26 +291,6 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
     _selectedRanges = [[NSMutableArray alloc] init];
     [_selectedRanges addObject: [NSValue valueWithRange: NSMakeRange(0, 0)]];
 
-    NSMutableDictionary *typingAttributes =
-            [[_textStorage attributesAtIndex: 0
-                              effectiveRange: NULL] mutableCopy];
-    if (![typingAttributes objectForKey: NSFontAttributeName]) {
-        [typingAttributes setObject: _font forKey: NSFontAttributeName];
-    }
-    if (![typingAttributes objectForKey: NSForegroundColorAttributeName]) {
-        [typingAttributes setObject: _textColor
-                             forKey: NSForegroundColorAttributeName];
-    }
-    _typingAttributes = typingAttributes;
-
-    if ([typingAttributes objectForKey: NSParagraphStyleAttributeName]) {
-        _defaultParagraphStyle = [[typingAttributes
-                objectForKey: NSParagraphStyleAttributeName] copy];
-    } else {
-        _defaultParagraphStyle =
-                [[NSParagraphStyle defaultParagraphStyle] copy];
-    }
-
     _rangeForUserCompletion = NSMakeRange(NSNotFound, 0);
     _selectedTextAttributes = [[NSDictionary
             dictionaryWithObjectsAndKeys: [NSColor selectedTextColor],
@@ -291,9 +299,12 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
                                           NSBackgroundColorAttributeName, nil]
             retain];
 
+    [self _setTextStorage: [[container layoutManager] textStorage]];
+
     [self setBoundsOrigin: NSMakePoint(-_textContainerInset.width,
                                        -_textContainerInset.height)];
     [self configureMenu];
+
     [self registerForDraggedTypes: [NSArray
                                            arrayWithObjects: NSRTFPboardType,
                                                              NSStringPboardType,
@@ -3389,9 +3400,7 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
 - (void) _continuousSpellCheckWithInvalidatedRange: (NSRange) invalidatedRange {
     NSString *string = [self string];
     NSUInteger start, end;
-
     // TODO, truncate invalidated range to string size if needed
-
     // round range to nearest paragraphs
 
     [string getParagraphStart: &start
@@ -3433,10 +3442,8 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
 }
 
 - (void) _continuousSpellCheck {
-    [self _continuousSpellCheckWithInvalidatedRange: NSMakeRange(
-                                                             0,
-                                                             [[self string]
-                                                                     length])];
+    NSRange invalidatedRange = NSMakeRange(0, [[self string] length]);
+    [self _continuousSpellCheckWithInvalidatedRange: invalidatedRange];
 }
 
 - (void) checkSpelling: sender {
@@ -3978,19 +3985,9 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
     return _layoutOrientation;
 }
 
-- (void)setLayoutOrientation:(NSTextLayoutOrientation)orientation {
+- (void) setLayoutOrientation: (NSTextLayoutOrientation) orientation {
     _layoutOrientation = orientation;
     NSUnimplementedMethod();
-}
-
-- (BOOL) usesFindBar {
-    NSUnimplementedMethod();
-    return _usesFindBar;
-}
-
-- (void) setUsesFindBar: (BOOL) value {
-    NSUnimplementedMethod();
-    _usesFindBar = value;
 }
 
 - (BOOL) isIncrementalSearchingEnabled {
@@ -3998,9 +3995,94 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
     return _incrementalSearchingEnabled;
 }
 
+- (BOOL) usesFindBar {
+    NSUnimplementedMethod();
+    return _usesFindBar;
+}
+
+- (BOOL) usesInspectorBar {
+    NSUnimplementedMethod();
+    return _usesInspectorBar;
+}
+
 - (void) setIncrementalSearchingEnabled: (BOOL) value {
     NSUnimplementedMethod();
     _incrementalSearchingEnabled = value;
+}
+
+- (void) setUsesFindBar: (BOOL) value {
+    NSUnimplementedMethod();
+    _usesFindBar = value;
+}
+
+- (void) setUsesInspectorBar: (BOOL) value {
+    NSUnimplementedMethod();
+    _usesInspectorBar = value;
+}
+
+- (BOOL) isGrammarCheckingEnabled {
+    NSUnimplementedMethod();
+    return _grammarCheckingEnabled;
+}
+
+- (BOOL) isAutomaticQuoteSubstitutionEnabled {
+    NSUnimplementedMethod();
+    return _automaticQuoteSubstitutionEnabled;
+}
+
+- (BOOL) isAutomaticDashSubstitutionEnabled {
+    NSUnimplementedMethod();
+    return _automaticDashSubstitutionEnabled;
+}
+
+- (BOOL) isAutomaticLinkDetectionEnabled {
+    NSUnimplementedMethod();
+    return _automaticLinkDetectionEnabled;
+}
+
+- (BOOL) isAutomaticDataDetectionEnabled {
+    NSUnimplementedMethod();
+    return _automaticDataDetectionEnabled;
+}
+
+- (BOOL) isAutomaticTextReplacementEnabled {
+    NSUnimplementedMethod();
+    return _automaticTextReplacementEnabled;
+}
+
+- (void) setGrammarCheckingEnabled: (BOOL) value {
+    NSUnimplementedMethod();
+    _grammarCheckingEnabled = value;
+}
+
+- (void) setAutomaticQuoteSubstitutionEnabled: (BOOL) value {
+    NSUnimplementedMethod();
+    _automaticQuoteSubstitutionEnabled = value;
+}
+
+- (void) setAutomaticDashSubstitutionEnabled: (BOOL) value {
+    NSUnimplementedMethod();
+    _automaticDashSubstitutionEnabled = value;
+}
+
+- (void) setAutomaticLinkDetectionEnabled: (BOOL) value {
+    NSUnimplementedMethod();
+    _automaticLinkDetectionEnabled = value;
+}
+
+- (void) setAutomaticDataDetectionEnabled: (BOOL) value {
+    NSUnimplementedMethod();
+    _automaticDataDetectionEnabled = value;
+}
+
+- (void) setAutomaticTextReplacementEnabled: (BOOL) value {
+    NSUnimplementedMethod();
+    _automaticTextReplacementEnabled = value;
+}
+
+// Is defined in NSText but throws an NSInvalidAbstractInvocation Exception
+- (void) setImportsGraphics: (BOOL) value {
+    NSUnimplementedMethod();
 }
 
 @end

--- a/AppKit/NSView.m
+++ b/AppKit/NSView.m
@@ -887,6 +887,10 @@ static inline void buildTransformsIfNeeded(NSView *self) {
     return toolTip;
 }
 
+- (BOOL) translatesAutoresizingMaskIntoConstraints {
+	return _translatesAutoresizingMaskIntoConstraints;
+}
+
 - viewWithTag: (NSInteger) tag {
     int i, count = [_subviews count];
 
@@ -1124,6 +1128,11 @@ static inline void buildTransformsIfNeeded(NSView *self) {
 
 - (void) setBoundsRotation: (CGFloat) angle {
     NSUnimplementedMethod();
+}
+
+- (void) settranslatesAutoresizingMaskIntoConstraints: (BOOL) value {
+	_translatesAutoresizingMaskIntoConstraints = value;
+	NSUnimplementedMethod();
 }
 
 - (void) setPostsFrameChangedNotifications: (BOOL) flag {

--- a/AppKit/NSView.m
+++ b/AppKit/NSView.m
@@ -888,7 +888,7 @@ static inline void buildTransformsIfNeeded(NSView *self) {
 }
 
 - (BOOL) translatesAutoresizingMaskIntoConstraints {
-	return _translatesAutoresizingMaskIntoConstraints;
+    return _translatesAutoresizingMaskIntoConstraints;
 }
 
 - viewWithTag: (NSInteger) tag {
@@ -1131,8 +1131,8 @@ static inline void buildTransformsIfNeeded(NSView *self) {
 }
 
 - (void) settranslatesAutoresizingMaskIntoConstraints: (BOOL) value {
-	_translatesAutoresizingMaskIntoConstraints = value;
-	NSUnimplementedMethod();
+    _translatesAutoresizingMaskIntoConstraints = value;
+    NSUnimplementedMethod();
 }
 
 - (void) setPostsFrameChangedNotifications: (BOOL) flag {

--- a/AppKit/NSView.m
+++ b/AppKit/NSView.m
@@ -887,10 +887,6 @@ static inline void buildTransformsIfNeeded(NSView *self) {
     return toolTip;
 }
 
-- (BOOL) translatesAutoresizingMaskIntoConstraints {
-    return _translatesAutoresizingMaskIntoConstraints;
-}
-
 - viewWithTag: (NSInteger) tag {
     int i, count = [_subviews count];
 
@@ -1127,11 +1123,6 @@ static inline void buildTransformsIfNeeded(NSView *self) {
 }
 
 - (void) setBoundsRotation: (CGFloat) angle {
-    NSUnimplementedMethod();
-}
-
-- (void) settranslatesAutoresizingMaskIntoConstraints: (BOOL) value {
-    _translatesAutoresizingMaskIntoConstraints = value;
     NSUnimplementedMethod();
 }
 

--- a/AppKit/X11.backend/X11Display.m
+++ b/AppKit/X11.backend/X11Display.m
@@ -592,10 +592,10 @@ static NSDictionary *modeInfoToDictionary(const XRRModeInfo *mi, int depth) {
     if ([colorName isEqual: @"windowFrameColor"])
         return [NSColor lightGrayColor];
     if ([colorName isEqual: @"selectedTextBackgroundColor"])
-        return [NSColor colorWithCalibratedRed: 0x33
-                                         green: 0x8f
-                                          blue: 0xff
-                                         alpha: 1.0f];
+        return [NSColor colorWithCalibratedRed: 0.20f
+                                         green: 0.55f
+                                          blue: 1.00f
+                                         alpha: 1.00f];
 
     NSLog(@"missing color for %@", colorName);
     return [NSColor redColor];

--- a/AppKit/include/AppKit/NSAttributedString.h
+++ b/AppKit/include/AppKit/NSAttributedString.h
@@ -26,102 +26,112 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 typedef NSString *NSAttributedStringDocumentReadingOptionKey;
 typedef NSString *NSAttributedStringDocumentAttributeKey;
+typedef NSString *NSAttributedStringDocumentType;
+typedef NSString *NSTextLayoutSectionKey;
 typedef NSString *NSAttributedStringKey;
 
-APPKIT_EXPORT NSString *const NSFontAttributeName;
-APPKIT_EXPORT NSString *const NSParagraphStyleAttributeName;
-APPKIT_EXPORT NSString *const NSForegroundColorAttributeName;
-APPKIT_EXPORT NSString *const NSBackgroundColorAttributeName;
-APPKIT_EXPORT NSString *const NSUnderlineStyleAttributeName;
-APPKIT_EXPORT NSString *const NSUnderlineColorAttributeName;
-APPKIT_EXPORT NSString *const NSAttachmentAttributeName;
-APPKIT_EXPORT NSString *const NSKernAttributeName;
-APPKIT_EXPORT NSString *const NSLigatureAttributeName;
-APPKIT_EXPORT NSString *const NSStrikethroughStyleAttributeName;
-APPKIT_EXPORT NSString *const NSStrikethroughColorAttributeName;
-APPKIT_EXPORT NSString *const NSObliquenessAttributeName;
-APPKIT_EXPORT NSString *const NSStrokeWidthAttributeName;
-APPKIT_EXPORT NSString *const NSStrokeColorAttributeName;
-APPKIT_EXPORT NSString *const NSBaselineOffsetAttributeName;
-APPKIT_EXPORT NSString *const NSSuperscriptAttributeName;
-APPKIT_EXPORT NSString *const NSLinkAttributeName;
-APPKIT_EXPORT NSString *const NSShadowAttributeName;
-APPKIT_EXPORT NSString *const NSExpansionAttributeName;
-APPKIT_EXPORT NSString *const NSCursorAttributeName;
-APPKIT_EXPORT NSString *const NSToolTipAttributeName;
+// The following constants are *not* declared as `const` in Apple's AppKit (they are located in __data)
+APPKIT_EXPORT NSAttributedStringKey NSFontAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSParagraphStyleAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSForegroundColorAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSBackgroundColorAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSUnderlineStyleAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSUnderlineColorAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSAttachmentAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSKernAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSLigatureAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSStrikethroughStyleAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSStrikethroughColorAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSObliquenessAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSStrokeWidthAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSStrokeColorAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSBaselineOffsetAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSSuperscriptAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSLinkAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSShadowAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSExpansionAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSCursorAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSToolTipAttributeName;
 
-APPKIT_EXPORT NSString *const NSSpellingStateAttributeName;
+// The following constant is *not* declared as `const` in Apple's AppKit (they are located in __data)
+APPKIT_EXPORT NSAttributedStringKey NSSpellingStateAttributeName;
 
-APPKIT_EXPORT NSString *const NSDocumentTypeDocumentAttribute;
-APPKIT_EXPORT NSString *const NSConvertedDocumentAttribute;
-APPKIT_EXPORT NSString *const NSFileTypeDocumentAttribute;
-APPKIT_EXPORT NSString *const NSTitleDocumentAttribute;
-APPKIT_EXPORT NSString *const NSCompanyDocumentAttribute;
-APPKIT_EXPORT NSString *const NSCopyrightDocumentAttribute;
-APPKIT_EXPORT NSString *const NSSubjectDocumentAttribute;
-APPKIT_EXPORT NSString *const NSAuthorDocumentAttribute;
-APPKIT_EXPORT NSString *const NSKeywordsDocumentAttribute;
-APPKIT_EXPORT NSString *const NSCommentDocumentAttribute;
-APPKIT_EXPORT NSString *const NSEditorDocumentAttribute;
-APPKIT_EXPORT NSString *const NSCreationTimeDocumentAttribute;
-APPKIT_EXPORT NSString *const NSModificationTimeDocumentAttribute;
-APPKIT_EXPORT NSString *const NSManagerDocumentAttribute;
-APPKIT_EXPORT NSString *const NSCategoryDocumentAttribute;
-APPKIT_EXPORT NSString *const NSAppearanceDocumentAttribute;
-APPKIT_EXPORT NSString *const NSCharacterEncodingDocumentAttribute;
-APPKIT_EXPORT NSString *const NSDefaultAttributesDocumentAttribute;
-APPKIT_EXPORT NSString *const NSPaperSizeDocumentAttribute;
-APPKIT_EXPORT NSString *const NSLeftMarginDocumentAttribute;
-APPKIT_EXPORT NSString *const NSRightMarginDocumentAttribute;
-APPKIT_EXPORT NSString *const NSTopMarginDocumentAttribute;
-APPKIT_EXPORT NSString *const NSBottomMarginDocumentAttribute;
-APPKIT_EXPORT NSString *const NSViewSizeDocumentAttribute;
-APPKIT_EXPORT NSString *const NSViewZoomDocumentAttribute;
-APPKIT_EXPORT NSString *const NSViewModeDocumentAttribute;
-APPKIT_EXPORT NSString *const NSReadOnlyDocumentAttribute;
-APPKIT_EXPORT NSString *const NSBackgroundColorDocumentAttribute;
-APPKIT_EXPORT NSString *const NSHyphenationFactorDocumentAttribute;
-APPKIT_EXPORT NSString *const NSDefaultTabIntervalDocumentAttribute;
-APPKIT_EXPORT NSString *const NSTextLayoutSectionsAttribute;
-APPKIT_EXPORT NSString *const NSExcludedElementsDocumentAttribute;
-APPKIT_EXPORT NSString *const NSTextEncodingNameDocumentAttribute;
-APPKIT_EXPORT NSString *const NSPrefixSpacesDocumentAttribute;
+// The following constants are *not* declared as `const` in Apple's AppKit (they are located in __data)
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSDocumentTypeDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSConvertedDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSFileTypeDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSTitleDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSCompanyDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSCopyrightDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSSubjectDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSAuthorDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSKeywordsDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSCommentDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSEditorDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSCreationTimeDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSModificationTimeDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSManagerDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSCategoryDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSAppearanceDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSCharacterEncodingDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSDefaultAttributesDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSPaperSizeDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSLeftMarginDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSRightMarginDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSTopMarginDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSBottomMarginDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSViewSizeDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSViewZoomDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSViewModeDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSReadOnlyDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSBackgroundColorDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSHyphenationFactorDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSDefaultTabIntervalDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSTextLayoutSectionsAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSExcludedElementsDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSTextEncodingNameDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSPrefixSpacesDocumentAttribute;
+APPKIT_EXPORT NSAttributedStringDocumentAttributeKey NSCocoaVersionDocumentAttribute;
 
-APPKIT_EXPORT NSString *const NSDocumentTypeDocumentOption;
-APPKIT_EXPORT NSString *const NSDefaultAttributesDocumentOption;
-APPKIT_EXPORT NSString *const NSCharacterEncodingDocumentOption;
-APPKIT_EXPORT NSString *const NSTextEncodingNameDocumentOption;
-APPKIT_EXPORT NSString *const NSBaseURLDocumentOption;
-APPKIT_EXPORT NSString *const NSTimeoutDocumentOption;
-APPKIT_EXPORT NSString *const NSWebPreferencesDocumentOption;
-APPKIT_EXPORT NSString *const NSWebResourceLoadDelegateDocumentOption;
-APPKIT_EXPORT NSString *const NSTextSizeMultiplierDocumentOption;
-APPKIT_EXPORT NSString *const NSFileTypeDocumentOption;
+// The following constants are *not* declared as `const` in Apple's AppKit (they are located in __data)
+APPKIT_EXPORT NSAttributedStringDocumentReadingOptionKey NSDocumentTypeDocumentOption;
+APPKIT_EXPORT NSAttributedStringDocumentReadingOptionKey NSDefaultAttributesDocumentOption;
+APPKIT_EXPORT NSAttributedStringDocumentReadingOptionKey NSCharacterEncodingDocumentOption;
+APPKIT_EXPORT NSAttributedStringDocumentReadingOptionKey NSTextEncodingNameDocumentOption;
+APPKIT_EXPORT NSAttributedStringDocumentReadingOptionKey NSBaseURLDocumentOption;
+APPKIT_EXPORT NSAttributedStringDocumentReadingOptionKey NSTimeoutDocumentOption;
+APPKIT_EXPORT NSAttributedStringDocumentReadingOptionKey NSWebPreferencesDocumentOption;
+APPKIT_EXPORT NSAttributedStringDocumentReadingOptionKey NSWebResourceLoadDelegateDocumentOption;
+APPKIT_EXPORT NSAttributedStringDocumentReadingOptionKey NSTextSizeMultiplierDocumentOption;
+APPKIT_EXPORT NSAttributedStringDocumentReadingOptionKey NSFileTypeDocumentOption;
 
-APPKIT_EXPORT NSString *const NSPlainTextDocumentType;
-APPKIT_EXPORT NSString *const NSRTFTextDocumentType;
-APPKIT_EXPORT NSString *const NSRTFDTextDocumentType;
-APPKIT_EXPORT NSString *const NSHTMLTextDocumentType;
-APPKIT_EXPORT NSString *const NSMacSimpleTextDocumentType;
-APPKIT_EXPORT NSString *const NSDocFormatTextDocumentType;
-APPKIT_EXPORT NSString *const NSWordMLTextDocumentType;
-APPKIT_EXPORT NSString *const NSWebArchiveTextDocumentType;
-APPKIT_EXPORT NSString *const NSOfficeOpenXMLTextDocumentType;
-APPKIT_EXPORT NSString *const NSOpenDocumentTextDocumentType;
+// The following constants are *not* declared as `const` in Apple's AppKit (they are located in __data)
+APPKIT_EXPORT NSAttributedStringDocumentType NSPlainTextDocumentType;
+APPKIT_EXPORT NSAttributedStringDocumentType NSRTFTextDocumentType;
+APPKIT_EXPORT NSAttributedStringDocumentType NSRTFDTextDocumentType;
+APPKIT_EXPORT NSAttributedStringDocumentType NSHTMLTextDocumentType;
+APPKIT_EXPORT NSAttributedStringDocumentType NSMacSimpleTextDocumentType;
+APPKIT_EXPORT NSAttributedStringDocumentType NSDocFormatTextDocumentType;
+APPKIT_EXPORT NSAttributedStringDocumentType NSWordMLTextDocumentType;
+APPKIT_EXPORT NSAttributedStringDocumentType NSWebArchiveTextDocumentType;
+APPKIT_EXPORT NSAttributedStringDocumentType NSOfficeOpenXMLTextDocumentType;
+APPKIT_EXPORT NSAttributedStringDocumentType NSOpenDocumentTextDocumentType;
 
-APPKIT_EXPORT NSString *const NSTextLayoutSectionOrientation;
-APPKIT_EXPORT NSString *const NSTextLayoutSectionRange;
+// The following constants are *not* declared as `const` in Apple's AppKit (they are located in __data)
+APPKIT_EXPORT NSTextLayoutSectionKey NSTextLayoutSectionOrientation;
+APPKIT_EXPORT NSTextLayoutSectionKey NSTextLayoutSectionRange;
 
-APPKIT_EXPORT NSString *const NSCharacterShapeAttributeName;
-APPKIT_EXPORT NSString *const NSUsesScreenFontsDocumentAttribute;
+// The following constants are *not* declared as `const` in Apple's AppKit (they are located in __data)
+APPKIT_EXPORT NSAttributedStringKey NSCharacterShapeAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSUsesScreenFontsDocumentAttribute;
 
-APPKIT_EXPORT NSString *const NSTextEffectAttributeName;
+APPKIT_EXPORT const NSAttributedStringKey NSTextEffectAttributeName;
+// The following constant is *not* declared as `const` in Apple's AppKit (they are located in __data)
 APPKIT_EXPORT NSAttributedStringKey NSWritingDirectionAttributeName;
-APPKIT_EXPORT NSString *const NSCocoaVersionDocumentAttribute;
 
+// The following constants are *not* declared as `const` in Apple's AppKit (they are located in __data)
 APPKIT_EXPORT NSUInteger NSUnderlineStrikethroughMask;
 APPKIT_EXPORT NSUInteger NSUnderlineByWordMask;
-
 
 enum {
     NSSpellingStateSpellingFlag = 0x01,
@@ -248,10 +258,11 @@ enum {
 
 #pragma mark -
 #pragma mark Getting Attribute Data
-- (void)enumerateAttribute:(NSAttributedStringKey)attrName 
-                   inRange:(NSRange)enumerationRange 
-                   options:(NSAttributedStringEnumerationOptions)opts 
-                usingBlock:(void (^)(id value, NSRange range, BOOL *stop))block;
+- (void) enumerateAttribute: (NSAttributedStringKey) attrName
+                    inRange: (NSRange) enumerationRange
+                    options: (NSAttributedStringEnumerationOptions) opts
+                 usingBlock:
+                         (void (^)(id value, NSRange range, BOOL *stop)) block;
 
 #pragma mark -
 #pragma mark Testing String Data Sources

--- a/AppKit/include/AppKit/NSAttributedString.h
+++ b/AppKit/include/AppKit/NSAttributedString.h
@@ -258,11 +258,10 @@ enum {
 
 #pragma mark -
 #pragma mark Getting Attribute Data
-- (void) enumerateAttribute: (NSAttributedStringKey) attrName
-                    inRange: (NSRange) enumerationRange
-                    options: (NSAttributedStringEnumerationOptions) opts
-                 usingBlock:
-                         (void (^)(id value, NSRange range, BOOL *stop)) block;
+- (void)enumerateAttribute: (NSAttributedStringKey) attrName 
+                   inRange: (NSRange) enumerationRange 
+                   options: (NSAttributedStringEnumerationOptions) opts 
+                usingBlock: (void (^)(id value, NSRange range, BOOL *stop)) block;
 
 #pragma mark -
 #pragma mark Testing String Data Sources

--- a/AppKit/include/AppKit/NSAttributedString.h
+++ b/AppKit/include/AppKit/NSAttributedString.h
@@ -24,6 +24,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 @class NSFont, NSColor, NSParagraphStyle, NSTextAttachment, NSFileWrapper,
         NSTextList, NSTextBlock, NSTextTable;
 
+typedef NSString *NSAttributedStringDocumentReadingOptionKey;
+typedef NSString *NSAttributedStringDocumentAttributeKey;
+typedef NSString *NSAttributedStringKey;
+
 APPKIT_EXPORT NSString *const NSFontAttributeName;
 APPKIT_EXPORT NSString *const NSParagraphStyleAttributeName;
 APPKIT_EXPORT NSString *const NSForegroundColorAttributeName;
@@ -112,9 +116,12 @@ APPKIT_EXPORT NSString *const NSCharacterShapeAttributeName;
 APPKIT_EXPORT NSString *const NSUsesScreenFontsDocumentAttribute;
 
 APPKIT_EXPORT NSString *const NSTextEffectAttributeName;
+APPKIT_EXPORT NSAttributedStringKey NSWritingDirectionAttributeName;
+APPKIT_EXPORT NSString *const NSCocoaVersionDocumentAttribute;
 
 APPKIT_EXPORT NSUInteger NSUnderlineStrikethroughMask;
 APPKIT_EXPORT NSUInteger NSUnderlineByWordMask;
+
 
 enum {
     NSSpellingStateSpellingFlag = 0x01,
@@ -238,6 +245,13 @@ enum {
 
 - (NSRect) boundingRectWithSize: (NSSize) size
                         options: (NSStringDrawingOptions) options;
+
+#pragma mark -
+#pragma mark Getting Attribute Data
+- (void)enumerateAttribute:(NSAttributedStringKey)attrName 
+                   inRange:(NSRange)enumerationRange 
+                   options:(NSAttributedStringEnumerationOptions)opts 
+                usingBlock:(void (^)(id value, NSRange range, BOOL *stop))block;
 
 #pragma mark -
 #pragma mark Testing String Data Sources

--- a/AppKit/include/AppKit/NSDocument.h
+++ b/AppKit/include/AppKit/NSDocument.h
@@ -23,18 +23,23 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 @class NSWindow, NSWindowController, NSSavePanel, NSMenuItem, NSFileWrapper,
         NSPrintOperation, NSPrintInfo, NSPageLayout, NSView;
 
-typedef enum {
+typedef enum NSDocumentChangeType : NSUInteger {
     NSChangeDone,
     NSChangeUndone,
     NSChangeCleared,
     NSChangeReadOtherContents,
     NSChangeAutosaved,
+    NSChangeRedone,
+    NSChangeDiscardable = 256,
 } NSDocumentChangeType;
 
 typedef enum {
     NSSaveOperation,
     NSSaveAsOperation,
     NSSaveToOperation,
+    NSAutosaveElsewhereOperation,
+    NSAutosaveInPlaceOperation,
+    NSAutosaveAsOperation,
     NSAutosaveOperation,
 } NSSaveOperationType;
 
@@ -230,7 +235,7 @@ typedef enum {
         (NSSaveOperationType) operation;
 - (NSFileWrapper *) fileWrapperRepresentationOfType: (NSString *) type;
 - initWithContentsOfFile: (NSString *) path ofType: (NSString *) type;
-- initWithContentsOfURL: (NSURL *) url ofType: (NSString *) type;
+- (id) initWithContentsOfURL: (NSURL *) url ofType: (NSString *) type;
 - (BOOL) loadDataRepresentation: (NSData *) data ofType: (NSString *) type;
 - (BOOL) loadFileWrapperRepresentation: (NSFileWrapper *) wrapper
                                 ofType: (NSString *) type;
@@ -258,5 +263,13 @@ typedef enum {
 - (BOOL) writeWithBackupToFile: (NSString *) path
                         ofType: (NSString *) type
                  saveOperation: (NSSaveOperationType) operation;
+
+- (void)saveToURL: (NSURL *) url 
+           ofType: (NSString *) typeName 
+ forSaveOperation: (NSSaveOperationType) saveOperation 
+completionHandler: (void (^)(NSError *errorOrNil)) completionHandler;
+
+- (void)autosaveWithImplicitCancellability: (BOOL) autosavingIsImplicitlyCancellable 
+                         completionHandler: (void (^)(NSError *errorOrNil)) completionHandler;
 
 @end

--- a/AppKit/include/AppKit/NSLayoutManager.h
+++ b/AppKit/include/AppKit/NSLayoutManager.h
@@ -32,6 +32,11 @@ typedef enum {
     NSGlyphInscribeOverBelow,
 } NSGlyphInscription;
 
+typedef NS_ENUM(NSInteger, NSTextLayoutOrientation) {
+    NSTextLayoutOrientationHorizontal,
+    NSTextLayoutOrientationVertical,
+};
+
 @interface NSLayoutManager : NSObject {
     NSTextStorage *_textStorage;
     NSGlyphGenerator *_glyphGenerator;
@@ -47,6 +52,7 @@ typedef enum {
     struct NSRangeEntries *_rangeToTemporaryAttributes;
 
     BOOL _layoutInvalid;
+    BOOL _allowsNonContiguousLayout;
 
     NSRect _extraLineFragmentRect;
     NSRect _extraLineFragmentUsedRect;
@@ -125,6 +131,8 @@ typedef enum {
 - (NSRect) extraLineFragmentRect;
 - (NSRect) extraLineFragmentUsedRect;
 - (NSTextContainer *) extraLineFragmentTextContainer;
+
+- (BOOL) allowsNonContiguousLayout;
 
 - (void) setTextContainer: (NSTextContainer *) container
             forGlyphRange: (NSRange) glyphRange;
@@ -268,6 +276,8 @@ typedef enum {
                             paragraphStyle: (NSParagraphStyle *) style
                                      ruler: (NSRulerView *) ruler
                                    enabled: (BOOL) isEnabled;
+
+- (void) setAllowsNonContiguousLayout: (BOOL) value;
 @end
 
 @protocol NSLayoutManagerDelegate <NSObject>
@@ -283,5 +293,7 @@ typedef enum {
 @end
 
 @protocol NSTextLayoutOrientationProvider
+
+- (NSTextLayoutOrientation) layoutOrientation;
 
 @end

--- a/AppKit/include/AppKit/NSMutableAttributedString.h
+++ b/AppKit/include/AppKit/NSMutableAttributedString.h
@@ -26,13 +26,13 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 - (void) fixAttributesInRange: (NSRange) range;
 - (void) applyFontTraits: (NSFontTraitMask) traits range: (NSRange) range;
 
-- (BOOL) readFromURL:(NSURL *)url 
-             options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)opts 
-  documentAttributes:(NSDictionary<NSAttributedStringDocumentAttributeKey, id> * _Nullable *)dict 
-               error:(NSError * _Nullable *)error;
+- (BOOL) readFromURL: (NSURL *) url 
+             options: (NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *) opts 
+  documentAttributes: (NSDictionary<NSAttributedStringDocumentAttributeKey, id> * _Nullable *) dict 
+               error: (NSError * _Nullable *)error;
 
-- (void)addAttribute:(NSAttributedStringKey)name 
-               value:(id)value 
-               range:(NSRange)range;
+- (void)addAttribute: (NSAttributedStringKey) name 
+               value: (id) value 
+               range: (NSRange) range;
 
 @end

--- a/AppKit/include/AppKit/NSMutableAttributedString.h
+++ b/AppKit/include/AppKit/NSMutableAttributedString.h
@@ -25,4 +25,14 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 - (void) fixParagraphStyleAttributeInRange: (NSRange) range;
 - (void) fixAttributesInRange: (NSRange) range;
 - (void) applyFontTraits: (NSFontTraitMask) traits range: (NSRange) range;
+
+- (BOOL) readFromURL:(NSURL *)url 
+             options:(NSDictionary<NSAttributedStringDocumentReadingOptionKey, id> *)opts 
+  documentAttributes:(NSDictionary<NSAttributedStringDocumentAttributeKey, id> * _Nullable *)dict 
+               error:(NSError * _Nullable *)error;
+
+- (void)addAttribute:(NSAttributedStringKey)name 
+               value:(id)value 
+               range:(NSRange)range;
+
 @end

--- a/AppKit/include/AppKit/NSMutableParagraphStyle.h
+++ b/AppKit/include/AppKit/NSMutableParagraphStyle.h
@@ -48,8 +48,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 - (void) setDefaultTabInterval: (CGFloat) interval;
 - (void) setTabStops: (NSArray *) tabStops;
-- (void) addTabStop:(NSTextTab *) tabStop;
-- (void) removeTabStop:(NSTextTab *) tabStop;
+- (void) addTabStop: (NSTextTab *) tabStop;
+- (void) removeTabStop: (NSTextTab *) tabStop;
 
 
 - (void) setHyphenationFactor: (float) factor;

--- a/AppKit/include/AppKit/NSMutableParagraphStyle.h
+++ b/AppKit/include/AppKit/NSMutableParagraphStyle.h
@@ -18,6 +18,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #import <AppKit/NSParagraphStyle.h>
+#import <AppKit/NSTextTab.h>
 
 @interface NSMutableParagraphStyle : NSParagraphStyle
 
@@ -47,6 +48,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 - (void) setDefaultTabInterval: (CGFloat) interval;
 - (void) setTabStops: (NSArray *) tabStops;
+- (void) addTabStop:(NSTextTab *) tabStop;
+- (void) removeTabStop:(NSTextTab *) tabStop;
+
 
 - (void) setHyphenationFactor: (float) factor;
 - (void) setTighteningFactorForTruncation: (float) factor;

--- a/AppKit/include/AppKit/NSParagraphStyle.h
+++ b/AppKit/include/AppKit/NSParagraphStyle.h
@@ -45,14 +45,14 @@ typedef enum {
     CGFloat _lineHeightMultiple;
     CGFloat _lineSpacing;
     CGFloat _defaultTabInterval;
-    NSArray *_tabStops;
+    NSMutableArray *_tabStops;
     float _hyphenationFactor;
     float _tighteningFactorForTruncation;
 }
 
 + (NSParagraphStyle *) defaultParagraphStyle;
 
-+ (NSWritingDirection)defaultWritingDirectionForLanguage:(NSString *)languageName;
++ (NSWritingDirection)defaultWritingDirectionForLanguage: (NSString *)languageName;
 
 - (NSWritingDirection) baseWritingDirection;
 

--- a/AppKit/include/AppKit/NSParagraphStyle.h
+++ b/AppKit/include/AppKit/NSParagraphStyle.h
@@ -52,6 +52,8 @@ typedef enum {
 
 + (NSParagraphStyle *) defaultParagraphStyle;
 
++ (NSWritingDirection)defaultWritingDirectionForLanguage:(NSString *)languageName;
+
 - (NSWritingDirection) baseWritingDirection;
 
 - (CGFloat) paragraphSpacing;

--- a/AppKit/include/AppKit/NSScrollView.h
+++ b/AppKit/include/AppKit/NSScrollView.h
@@ -19,6 +19,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
 #import <AppKit/AppKitExport.h>
 #import <AppKit/NSView.h>
+#import <AppKit/NSControl.h>
+#import <AppKit/NSScroller.h>
 #import <Foundation/NSString.h>
 
 @class NSClipView, NSScroller, NSColor, NSRulerView;
@@ -50,16 +52,32 @@ APPKIT_EXPORT NSString *const NSScrollViewDidLiveScrollNotification;
     BOOL _scrollsDynamically;
     BOOL _autohidesScrollers;
     NSCursor *_documentCursor;
+    BOOL _allowsMagnification;
+    CGFloat _magnification;
+    CGFloat _minMagnification;
+    CGFloat _maxMagnification;
 }
 
 + (NSSize) frameSizeForContentSize: (NSSize) contentSize
              hasHorizontalScroller: (BOOL) hasHorizontalScroller
                hasVerticalScroller: (BOOL) hasVerticalScroller
                         borderType: (NSBorderType) borderType;
++ (NSSize)frameSizeForContentSize:(NSSize)cSize 
+          horizontalScrollerClass:(Class)horizontalScrollerClass 
+            verticalScrollerClass:(Class)verticalScrollerClass 
+                       borderType:(NSBorderType)type 
+                      controlSize:(NSControlSize)controlSize 
+                    scrollerStyle:(NSScrollerStyle)scrollerStyle;
 + (NSSize) contentSizeForFrameSize: (NSSize) fSize
              hasHorizontalScroller: (BOOL) hasHorizontalScroller
                hasVerticalScroller: (BOOL) hasVerticalScroller
                         borderType: (NSBorderType) borderType;
++ (NSSize)contentSizeForFrameSize:(NSSize)fSize 
+          horizontalScrollerClass:(Class)horizontalScrollerClass 
+            verticalScrollerClass:(Class)verticalScrollerClass 
+                       borderType:(NSBorderType)type 
+                      controlSize:(NSControlSize)controlSize 
+                    scrollerStyle:(NSScrollerStyle)scrollerStyle;
 
 + (void) setRulerViewClass: (Class) aClass;
 + (Class) rulerViewClass;
@@ -94,6 +112,10 @@ APPKIT_EXPORT NSString *const NSScrollViewDidLiveScrollNotification;
 - (BOOL) autohidesScrollers;
 
 - (NSCursor *) documentCursor;
+- (CGFloat) magnification;
+- (CGFloat) minMagnification;
+- (CGFloat) maxMagnification;
+- (BOOL) allowsMagnification;
 
 - (void) setDocumentView: (NSView *) view;
 - (void) setContentView: (NSClipView *) clipView;
@@ -116,6 +138,10 @@ APPKIT_EXPORT NSString *const NSScrollViewDidLiveScrollNotification;
 - (void) setScrollsDynamically: (BOOL) flag;
 - (void) setDocumentCursor: (NSCursor *) cursor;
 - (void) setAutohidesScrollers: (BOOL) value;
+- (void) setMagnification: (CGFloat) value;
+- (void) setMinMagnification: (CGFloat) value;
+- (void) setMaxMagnification: (CGFloat) value;
+- (BOOL) setAllowsMagnification: (BOOL) value;
 
 - (void) tile;
 - (void) reflectScrolledClipView: (NSClipView *) clipView;

--- a/AppKit/include/AppKit/NSScrollView.h
+++ b/AppKit/include/AppKit/NSScrollView.h
@@ -62,22 +62,22 @@ APPKIT_EXPORT NSString *const NSScrollViewDidLiveScrollNotification;
              hasHorizontalScroller: (BOOL) hasHorizontalScroller
                hasVerticalScroller: (BOOL) hasVerticalScroller
                         borderType: (NSBorderType) borderType;
-+ (NSSize)frameSizeForContentSize:(NSSize)cSize 
-          horizontalScrollerClass:(Class)horizontalScrollerClass 
-            verticalScrollerClass:(Class)verticalScrollerClass 
-                       borderType:(NSBorderType)type 
-                      controlSize:(NSControlSize)controlSize 
-                    scrollerStyle:(NSScrollerStyle)scrollerStyle;
++ (NSSize)frameSizeForContentSize: (NSSize)cSize 
+          horizontalScrollerClass: (Class)horizontalScrollerClass 
+            verticalScrollerClass: (Class)verticalScrollerClass 
+                       borderType: (NSBorderType)type 
+                      controlSize: (NSControlSize)controlSize 
+                    scrollerStyle: (NSScrollerStyle)scrollerStyle;
 + (NSSize) contentSizeForFrameSize: (NSSize) fSize
              hasHorizontalScroller: (BOOL) hasHorizontalScroller
                hasVerticalScroller: (BOOL) hasVerticalScroller
                         borderType: (NSBorderType) borderType;
-+ (NSSize)contentSizeForFrameSize:(NSSize)fSize 
-          horizontalScrollerClass:(Class)horizontalScrollerClass 
-            verticalScrollerClass:(Class)verticalScrollerClass 
-                       borderType:(NSBorderType)type 
-                      controlSize:(NSControlSize)controlSize 
-                    scrollerStyle:(NSScrollerStyle)scrollerStyle;
++ (NSSize)contentSizeForFrameSize: (NSSize)fSize 
+          horizontalScrollerClass: (Class)horizontalScrollerClass 
+            verticalScrollerClass: (Class)verticalScrollerClass 
+                       borderType: (NSBorderType)type 
+                      controlSize: (NSControlSize)controlSize 
+                    scrollerStyle: (NSScrollerStyle)scrollerStyle;
 
 + (void) setRulerViewClass: (Class) aClass;
 + (Class) rulerViewClass;
@@ -141,7 +141,7 @@ APPKIT_EXPORT NSString *const NSScrollViewDidLiveScrollNotification;
 - (void) setMagnification: (CGFloat) value;
 - (void) setMinMagnification: (CGFloat) value;
 - (void) setMaxMagnification: (CGFloat) value;
-- (BOOL) setAllowsMagnification: (BOOL) value;
+- (void) setAllowsMagnification: (BOOL) value;
 
 - (void) tile;
 - (void) reflectScrolledClipView: (NSClipView *) clipView;

--- a/AppKit/include/AppKit/NSScroller.h
+++ b/AppKit/include/AppKit/NSScroller.h
@@ -86,7 +86,7 @@ typedef NSUInteger NSUsableScrollerParts;
         knobProportion: (CGFloat) zeroToOneKnob;
 - (void) setArrowsPosition: (NSScrollArrowPosition) position;
 - (void) setControlSize: (NSControlSize) value;
-- (void) setScrollerStyle : (NSScrollerStyle) style;
+- (void) setScrollerStyle: (NSScrollerStyle) style;
 
 - (NSRect) rectForPart: (NSScrollerPart) part;
 - (void) checkSpaceForParts;

--- a/AppKit/include/AppKit/NSScroller.h
+++ b/AppKit/include/AppKit/NSScroller.h
@@ -46,6 +46,12 @@ enum {
     NSOnlyScrollerArrows = 1,
     NSAllScrollerParts = 2,
 };
+
+typedef NS_ENUM(NSInteger, NSScrollerStyle) {
+    NSScrollerStyleLegacy,
+    NSScrollerStyleOverlay,
+};
+
 typedef NSUInteger NSUsableScrollerParts;
 
 @interface NSScroller : NSControl {
@@ -64,6 +70,8 @@ typedef NSUInteger NSUsableScrollerParts;
     NSScrollerPart _hitPart;
     BOOL _isEnabled;
     BOOL _isHighlighted;
+
+    NSScrollerStyle _scrollerStyle;
 }
 
 + (CGFloat) scrollerWidth;
@@ -71,11 +79,14 @@ typedef NSUInteger NSUsableScrollerParts;
 - (CGFloat) knobProportion;
 - (NSScrollArrowPosition) arrowsPosition;
 - (NSControlSize) controlSize;
+- (NSScrollerStyle) scrollerStyle;
++ (NSScrollerStyle) preferredScrollerStyle;
 
 - (void) setFloatValue: (float) zeroToOneValue
         knobProportion: (CGFloat) zeroToOneKnob;
 - (void) setArrowsPosition: (NSScrollArrowPosition) position;
 - (void) setControlSize: (NSControlSize) value;
+- (void) setScrollerStyle : (NSScrollerStyle) style;
 
 - (NSRect) rectForPart: (NSScrollerPart) part;
 - (void) checkSpaceForParts;

--- a/AppKit/include/AppKit/NSTextTab.h
+++ b/AppKit/include/AppKit/NSTextTab.h
@@ -49,4 +49,5 @@ APPKIT_EXPORT NSString *NSTabColumnTerminatorsAttributeName;
 
 - (CGFloat) location;
 
+- (NSComparisonResult) compare: (id) anObject;
 @end

--- a/AppKit/include/AppKit/NSTextView.h
+++ b/AppKit/include/AppKit/NSTextView.h
@@ -30,6 +30,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #import <AppKit/NSText.h>
 #import <AppKit/NSTextInput.h>
 #import <AppKit/NSTextInputClient.h>
+#import <AppKit/NSLayoutManager.h>
 
 #import <Foundation/NSTextCheckingResult.h>
 
@@ -68,7 +69,7 @@ APPKIT_EXPORT NSString *const NSAllRomanInputSourcesLocaleIdentifier;
 
 @class NSUndoTyping;
 
-@interface NSTextView : NSText <NSTextInput> {
+@interface NSTextView : NSText <NSTextInput, NSTextLayoutOrientationProvider> {
     NSTextStorage *_textStorage;
     NSTextContainer *_textContainer;
     NSSize _textContainerInset;
@@ -98,6 +99,7 @@ APPKIT_EXPORT NSString *const NSAllRomanInputSourcesLocaleIdentifier;
     BOOL _usesRuler;
     BOOL _rulerVisible;
     BOOL _usesFontPanel;
+    BOOL _usesFindBar;
     BOOL _allowsUndo;
 
     NSMutableArray *_selectedRanges;
@@ -129,8 +131,14 @@ APPKIT_EXPORT NSString *const NSAllRomanInputSourcesLocaleIdentifier;
     BOOL _isContinuousSpellCheckingEnabled;
     BOOL _isAutomaticSpellingCorrectionEnabled;
     NSTextCheckingTypes _enabledTextCheckingTypes;
+    BOOL _smartInsertDeleteEnabled;
+
+    BOOL _allowsDocumentBackgroundColorChange;
 
     NSUndoTyping *_undoTyping;
+    NSTextLayoutOrientation _layoutOrientation;
+
+    BOOL _incrementalSearchingEnabled;
 }
 
 - initWithFrame: (NSRect) frame textContainer: (NSTextContainer *) container;
@@ -250,7 +258,20 @@ APPKIT_EXPORT NSString *const NSAllRomanInputSourcesLocaleIdentifier;
 - (NSTextCheckingTypes) enabledTextCheckingTypes;
 - (void) setEnabledTextCheckingTypes: (NSTextCheckingTypes) checkingTypes;
 
+- (BOOL) smartInsertDeleteEnabled;
+- (void) setSmartInsertDeleteEnabled: (BOOL) boolForKey;
+
+- (BOOL) allowsDocumentBackgroundColorChange;
+- (void) setAllowsDocumentBackgroundColorChange: (BOOL) value;
+
 - (void) setSpellingState: (NSInteger) value range: (NSRange) characterRange;
+
+- (BOOL) usesFindBar;
+- (void) setUsesFindBar: (BOOL) value;
+- (BOOL) isIncrementalSearchingEnabled;
+- (void) setIncrementalSearchingEnabled: (BOOL) value;
+
+- (void) setLayoutOrientation:(NSTextLayoutOrientation)orientation;
 
 @end
 

--- a/AppKit/include/AppKit/NSTextView.h
+++ b/AppKit/include/AppKit/NSTextView.h
@@ -139,11 +139,21 @@ APPKIT_EXPORT NSString *const NSAllRomanInputSourcesLocaleIdentifier;
     NSTextLayoutOrientation _layoutOrientation;
 
     BOOL _incrementalSearchingEnabled;
+    BOOL _grammarCheckingEnabled;
+    BOOL _automaticQuoteSubstitutionEnabled;
+    BOOL _automaticDashSubstitutionEnabled;
+    BOOL _automaticLinkDetectionEnabled;
+    BOOL _automaticDataDetectionEnabled;
+    BOOL _automaticTextReplacementEnabled;
+
+    BOOL _usesInspectorBar;
 }
 
 - initWithFrame: (NSRect) frame textContainer: (NSTextContainer *) container;
 
 - initWithFrame: (NSRect) frame;
+
+- (void) _setTextStorage: (NSTextStorage *) storage;
 
 - (NSTextContainer *) textContainer;
 
@@ -266,12 +276,27 @@ APPKIT_EXPORT NSString *const NSAllRomanInputSourcesLocaleIdentifier;
 
 - (void) setSpellingState: (NSInteger) value range: (NSRange) characterRange;
 
-- (BOOL) usesFindBar;
-- (void) setUsesFindBar: (BOOL) value;
 - (BOOL) isIncrementalSearchingEnabled;
+- (BOOL) usesFindBar;
+- (BOOL) usesInspectorBar;
 - (void) setIncrementalSearchingEnabled: (BOOL) value;
+- (void) setUsesFindBar: (BOOL) value;
+- (void) setUsesInspectorBar: (BOOL) value;
 
 - (void) setLayoutOrientation:(NSTextLayoutOrientation)orientation;
+
+- (BOOL) isGrammarCheckingEnabled;
+- (BOOL) isAutomaticQuoteSubstitutionEnabled;
+- (BOOL) isAutomaticDashSubstitutionEnabled;
+- (BOOL) isAutomaticLinkDetectionEnabled;
+- (BOOL) isAutomaticDataDetectionEnabled;
+- (BOOL) isAutomaticTextReplacementEnabled;
+- (void) setGrammarCheckingEnabled: (BOOL) value;
+- (void) setAutomaticQuoteSubstitutionEnabled: (BOOL) value;
+- (void) setAutomaticDashSubstitutionEnabled: (BOOL) value;
+- (void) setAutomaticLinkDetectionEnabled: (BOOL) value;
+- (void) setAutomaticDataDetectionEnabled: (BOOL) value;
+- (void) setAutomaticTextReplacementEnabled: (BOOL) value;
 
 @end
 

--- a/AppKit/include/AppKit/NSView.h
+++ b/AppKit/include/AppKit/NSView.h
@@ -136,7 +136,6 @@ APPKIT_EXPORT const NSViewFullScreenModeOptionKey NSFullScreenModeApplicationPre
     NSLayoutPriority _verticalContentHuggingPriority;
     NSLayoutPriority _horizontalContentCompressionResistancePriority;
     NSLayoutPriority _verticalContentCompressionResistancePriority;
-    BOOL _translatesAutoresizingMaskIntoConstraints;
 }
 
 @property(class, readonly) BOOL requiresConstraintBasedLayout;
@@ -205,7 +204,6 @@ APPKIT_EXPORT const NSViewFullScreenModeOptionKey NSFullScreenModeApplicationPre
 - (NSMenu *) menuForEvent: (NSEvent *) event;
 - (NSMenuItem *) enclosingMenuItem;
 - (NSString *) toolTip;
-- (BOOL) translatesAutoresizingMaskIntoConstraints;
 
 - viewWithTag: (NSInteger) tag;
 - (NSView *) hitTest: (NSPoint) point;
@@ -228,7 +226,6 @@ APPKIT_EXPORT const NSViewFullScreenModeOptionKey NSFullScreenModeApplicationPre
 - (void) setBoundsSize: (NSSize) size;
 - (void) setBoundsOrigin: (NSPoint) origin;
 - (void) setBoundsRotation: (CGFloat) angle;
-- (void) setTranslatesAutoresizingMaskIntoConstraints: (BOOL) value;
 
 - (CGFloat) frameRotation;
 - (CGFloat) boundsRotation;

--- a/AppKit/include/AppKit/NSView.h
+++ b/AppKit/include/AppKit/NSView.h
@@ -109,6 +109,7 @@ APPKIT_EXPORT const NSViewFullScreenModeOptionKey NSFullScreenModeApplicationPre
     NSInteger _rectsBeingRedrawnCount;
     CGFloat _frameRotation;
     CGFloat _boundsRotation;
+    BOOL _translatesAutoresizingMaskIntoConstraints;
 
     BOOL _validTrackingAreas;
     BOOL _validTransforms;
@@ -203,6 +204,7 @@ APPKIT_EXPORT const NSViewFullScreenModeOptionKey NSFullScreenModeApplicationPre
 - (NSMenu *) menuForEvent: (NSEvent *) event;
 - (NSMenuItem *) enclosingMenuItem;
 - (NSString *) toolTip;
+- (BOOL) translatesAutoresizingMaskIntoConstraints;
 
 - viewWithTag: (NSInteger) tag;
 - (NSView *) hitTest: (NSPoint) point;
@@ -225,6 +227,7 @@ APPKIT_EXPORT const NSViewFullScreenModeOptionKey NSFullScreenModeApplicationPre
 - (void) setBoundsSize: (NSSize) size;
 - (void) setBoundsOrigin: (NSPoint) origin;
 - (void) setBoundsRotation: (CGFloat) angle;
+- (void) setTranslatesAutoresizingMaskIntoConstraints: (BOOL) value;
 
 - (CGFloat) frameRotation;
 - (CGFloat) boundsRotation;

--- a/AppKit/include/AppKit/NSView.h
+++ b/AppKit/include/AppKit/NSView.h
@@ -24,6 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #import <AppKit/NSAnimation.h>
 #import <AppKit/NSGraphics.h>
 #import <AppKit/NSResponder.h>
+#import <AppKit/NSUserInterfaceItemIdentification.h>
 #import <ApplicationServices/ApplicationServices.h>
 #import <AppKit/NSUserInterfaceItemIdentification.h>
 #import <AppKit/NSLayoutConstraint.h>


### PR DESCRIPTION
Adds stubs and implements missing functionality as required for [Apple TextEdit](https://github.com/darlinghq/darling-TextEdit) to compile and run. 
Also note the following related PRs:
:white_check_mark: [CoreFoundation](https://github.com/darlinghq/darling-corefoundation/pull/6)
:white_check_mark: [LaunchServices](https://github.com/darlinghq/darling/pull/1352)
:white_check_mark: [AppleEvents Stubs](https://github.com/darlinghq/darling/pull/1363)
:white_check_mark: [TextEdit CMake](https://github.com/darlinghq/darling-TextEdit/pull/1)

Fixes [Issue 383](https://github.com/darlinghq/darling/issues/383)
![TextEdit running on Darling](https://github.com/darlinghq/darling-cocotron/assets/57967583/ab224018-8483-490e-b377-49d967c41959)
