### PR TITLE
Correct NSInteger warnings

### DIFF
--- a/AppKit/CoreData_/_NSManagedProxy.m
+++ b/AppKit/CoreData_/_NSManagedProxy.m
@@ -130,7 +130,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     else
         result = [_fetchRequest _countInContext: _context];
     NSLog(@"%@ being asked about its count and saying %lu; %@ %@\n", self,
-          result, _context, _fetchRequest);
+          (unsigned long) result, _context, _fetchRequest);
     return result;
 }
 

--- a/AppKit/MacWorkspace.m
+++ b/AppKit/MacWorkspace.m
@@ -245,7 +245,7 @@
     [NSApp hideOtherApplications: self];
 }
 
-- (int) extendPowerOffBy: (int) milliseconds {
+- (NSInteger) extendPowerOffBy: (NSInteger) milliseconds {
     return 0;
 }
 

--- a/AppKit/NSBezierPath.m
+++ b/AppKit/NSBezierPath.m
@@ -354,8 +354,8 @@ static void CGPathConverter(void *info, const CGPathElement *element) {
 - (NSBezierPathElement) elementAtIndex: (int) index {
     if (index >= _numberOfElements)
         [NSException raise: NSInvalidArgumentException
-                    format: @"index (%d) >= numberOfElements (%d)", index,
-                            _numberOfElements];
+                    format: @"index (%d) >= numberOfElements (%lu)", index,
+                            (unsigned long) _numberOfElements];
 
     return _elements[index];
 }
@@ -385,8 +385,8 @@ static int numberOfPointsForOperator(int op) {
 
     if (index >= _numberOfElements)
         [NSException raise: NSInvalidArgumentException
-                    format: @"index (%d) >= numberOfElements (%d)", index,
-                            _numberOfElements];
+                    format: @"index (%d) >= numberOfElements (%lu)", index,
+                            (unsigned long) _numberOfElements];
 
     for (i = 0; i < index; i++)
         pi += numberOfPointsForOperator(_elements[i]);
@@ -1037,8 +1037,8 @@ static inline CGFloat degreesToRadians(CGFloat degrees) {
 
     if (index >= _numberOfElements)
         [NSException raise: NSInvalidArgumentException
-                    format: @"index (%d) >= numberOfElements (%d)", index,
-                            _numberOfElements];
+                    format: @"index (%d) >= numberOfElements (%lu)", index,
+                            (unsigned long) _numberOfElements];
 
     for (i = 0; i < index; i++)
         pi += numberOfPointsForOperator(_elements[i]);

--- a/AppKit/NSButtonCell.m
+++ b/AppKit/NSButtonCell.m
@@ -197,7 +197,7 @@ static const CGFloat kImageMargin = 2.;
                                     // in synch with the bare _state of NSCell
     } else {
         NSInteger version = [coder versionForClassName: @"NSButtonCell"];
-        NSLog(@"NSButtonCell version is %d\n", version);
+        NSLog(@"NSButtonCell version is %ld\n", (long) version);
         unichar keyEquivModMask;
         if (version <= 16) {
             if ([(NSUnarchiver *) coder systemVersion] > 82) {

--- a/AppKit/NSCell.m
+++ b/AppKit/NSCell.m
@@ -284,9 +284,9 @@ typedef NS_OPTIONS(unsigned int, NSCellAppleFlags2) {
         if (version < 54)
             [NSException raise: NSInvalidArgumentException
                         format: @"%@ can not initWithCoder:%@ for version %ld",
-                                [self class], [coder class], version];
+                                [self class], [coder class], (long) version];
 
-        NSLog(@"NSCell version is %d\n", version);
+        NSLog(@"NSCell version is %ld\n", (long) version);
         [coder decodeValuesOfObjCTypes: "ii", &flags, &flags2];
 
         /*
@@ -442,7 +442,7 @@ typedef NS_OPTIONS(unsigned int, NSCellAppleFlags2) {
         else
             return 0;
     } else
-        return (abs(_state) > 0) ? 1 : 0;
+        return (ABS(_state) > 0) ? 1 : 0;
 }
 
 - target {
@@ -716,7 +716,7 @@ typedef NS_OPTIONS(unsigned int, NSCellAppleFlags2) {
         else
             _state = 0;
     } else
-        _state = (abs(value) > 0) ? 1 : 0;
+        _state = (ABS(value) > 0) ? 1 : 0;
 }
 
 - (NSControlStateValue) nextState {
@@ -1297,7 +1297,7 @@ static NSString *NSStringFromCellType(NSCellType type) {
     default:
         break;
     }
-    return [NSString stringWithFormat: @"Unknown: %d", type];
+    return [NSString stringWithFormat: @"Unknown: %lu", (unsigned long) type];
 }
 
 - (NSString *) description {

--- a/AppKit/NSControl.m
+++ b/AppKit/NSControl.m
@@ -95,7 +95,7 @@ static NSMutableDictionary *cellClassDictionary = nil;
         [_aux setTarget: [keyed decodeObjectForKey: @"NSControlTarget"]];
     } else {
         NSInteger version = [coder versionForClassName: @"NSControl"];
-        NSLog(@"NSControl version is %d\n", version);
+        NSLog(@"NSControl version is %ld\n", (long) version);
 
         if (version <= 16) {
             NSInteger tag;

--- a/AppKit/NSDatePickerCell.m
+++ b/AppKit/NSDatePickerCell.m
@@ -226,9 +226,9 @@ static void drawRoundedSelection(NSRect rect) {
                                                     fromDate: [self dateValue]];
 
         NSString *month =
-                [NSString stringWithFormat: @"%d", [components month]];
-        NSString *day = [NSString stringWithFormat: @"%d", [components day]];
-        NSString *year = [NSString stringWithFormat: @"%d", [components year]];
+                [NSString stringWithFormat: @"%ld", (long) [components month]];
+        NSString *day = [NSString stringWithFormat: @"%ld", (long) [components day]];
+        NSString *year = [NSString stringWithFormat: @"%ld", (long) [components year]];
 
         [attributes
                 setObject: [NSNumber numberWithUnsignedInteger: [components

--- a/AppKit/NSEvent.subproj/NSEvent.m
+++ b/AppKit/NSEvent.subproj/NSEvent.m
@@ -243,7 +243,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 - (NSString *) description {
     return [NSString
             stringWithFormat:
-                    @"<NSEvent: type=%lu loc=(%f,%f) time=%f flags=0x%X "
+                    @"<NSEvent: type=%lu loc=(%f,%f) time=%f flags=0x%lX "
                     @"win=%p winNum=%lu>",
                     (unsigned long) [self type], [self locationInWindow].x,
                     [self locationInWindow].y, [self timestamp],

--- a/AppKit/NSFont.m
+++ b/AppKit/NSFont.m
@@ -376,7 +376,7 @@ static NSLock *_cacheLock = nil;
     } else {
         NSInteger version = [coder versionForClassName: @"NSFont"];
 
-        NSLog(@"NSFont version is %d\n", version);
+        NSLog(@"NSFont version is %ld\n", (long) version);
 
         unsigned int fFlags = 0;
         bool f2;

--- a/AppKit/NSImageRep.m
+++ b/AppKit/NSImageRep.m
@@ -347,9 +347,9 @@ static NSMutableArray *_registeredClasses = nil;
     return [NSString
             stringWithFormat:
                     @"<%@[%p] size: { %f, %f } colorSpace: %@ (%dx%d @ "
-                    @"%d bps) alpha: %@ opaque: %@>",
+                    @"%ld bps) alpha: %@ opaque: %@>",
                     [self class], self, _size.width, _size.height,
-                    _colorSpaceName, _pixelsWide, _pixelsHigh, _bitsPerSample,
+                    _colorSpaceName, _pixelsWide, _pixelsHigh, (long) _bitsPerSample,
                     _hasAlpha ? @"YES" : @"NO", _isOpaque ? @"YES" : @"NO"];
 }
 

--- a/AppKit/NSKeyValueBinding/NSMultipleValueBinder.m
+++ b/AppKit/NSKeyValueBinding/NSMultipleValueBinder.m
@@ -56,8 +56,8 @@ static void *NSMultipleValueBinderWholeArrayChangeContext;
                                   valueForKeyPath: _valueKeyPath]
                   forKey: path];
     } @catch (id e) {
-        NSLog(@"exception %@ while setting value for key path %@ for row %i", e,
-              _valueKeyPath, row);
+        NSLog(@"exception %@ while setting value for key path %@ for row %ld", e,
+              _valueKeyPath, (long) row);
     }
 }
 

--- a/AppKit/NSSegmentedControl/NSSegmentItem.m
+++ b/AppKit/NSSegmentedControl/NSSegmentItem.m
@@ -43,9 +43,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 }
 
 - (id) description {
-    return [NSString stringWithFormat: @"%@ - %@ (%f) [%d]",
+    return [NSString stringWithFormat: @"%@ - %@ (%f) [%ld]",
                                        [super description], _label, _width,
-                                       _tag];
+                                       (long) _tag];
 }
 
 - (void) dealloc {

--- a/AppKit/NSTableHeaderView.m
+++ b/AppKit/NSTableHeaderView.m
@@ -74,9 +74,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
     if (column < 0 || column >= [[_tableView tableColumns] count]) {
         [NSException raise: NSInternalInconsistencyException
-                    format: @"headerRectOfColumn: invalid index %d (valid {%d, "
-                            @"%d})",
-                            column, 0, [tableColumns count]];
+                    format: @"headerRectOfColumn: invalid index %ld (valid {%d, "
+                            @"%lu})",
+                            (long) column, 0, (unsigned long) [tableColumns count]];
     }
 
     headerRect.size.width =

--- a/AppKit/NSTableView.m
+++ b/AppKit/NSTableView.m
@@ -400,8 +400,8 @@ static CGFloat rowHeightAtIndex(NSTableView *self, NSInteger index) {
 
     if (column < 0 || column >= [_tableColumns count]) {
         [NSException raise: NSInternalInconsistencyException
-                    format: @"rectOfColumn: invalid index %d (valid {%d, %d})",
-                            column, 0, [_tableColumns count]];
+                    format: @"rectOfColumn: invalid index %ld (valid {%d, %lu})",
+                            (long) column, 0, (unsigned long) [_tableColumns count]];
     }
 
     rect.origin.x = 0.;
@@ -1110,8 +1110,8 @@ static CGFloat rowHeightAtIndex(NSTableView *self, NSInteger index) {
     if ([indexSet firstIndex] != NSNotFound &&
         ([indexSet firstIndex] < 0 || [indexSet lastIndex] >= numberOfRows))
         [NSException raise: NSInternalInconsistencyException
-                    format: @"Index set %@ out of range (valid are 0 to %d).",
-                            indexSet, numberOfRows];
+                    format: @"Index set %@ out of range (valid are 0 to %ld).",
+                            indexSet, (long) numberOfRows];
 
     _rowHeights = realloc(_rowHeights, sizeof(CGFloat) * numberOfRows);
 

--- a/AppKit/NSTextFieldCell.m
+++ b/AppKit/NSTextFieldCell.m
@@ -67,7 +67,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
                 [[keyed decodeObjectForKey: @"NSPlaceholderString"] retain];
     } else {
         NSInteger version = [coder versionForClassName: @"NSTextFieldCell"];
-        NSLog(@"NSTextFieldCell version is %d\n", version);
+        NSLog(@"NSTextFieldCell version is %ld\n", (long) version);
         if (version > 40) {
             uint8_t flags;
             [coder decodeValuesOfObjCTypes: "c@@", &flags, &_backgroundColor,

--- a/AppKit/NSTextView.subproj/NSTextStorage_concrete.m
+++ b/AppKit/NSTextView.subproj/NSTextStorage_concrete.m
@@ -69,8 +69,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 {
     NSDictionary *result;
 
-    NSAssert2(location <= [self length], @"index %d beyond length %d", location,
-              [self length]);
+    NSAssert2(location <= [self length], @"index %lu beyond length %lu", (unsigned long) location,
+              (unsigned long) [self length]);
 
     if ((result = NSRangeEntryAtIndex(_rangeToAttributes, location,
                                       effectiveRangep)) == nil)

--- a/AppKit/NSTextView.subproj/NSTextView.m
+++ b/AppKit/NSTextView.subproj/NSTextView.m
@@ -1321,7 +1321,7 @@ NSString *const NSAllRomanInputSourcesLocaleIdentifier =
     }
 
     delta -= (upstream ? range.location : NSMaxRange(range));
-    delta = abs(delta);
+    delta = ABS(delta);
 
     if (upstream && range.location > 0) {
         range.location -= delta;

--- a/AppKit/NSView.m
+++ b/AppKit/NSView.m
@@ -287,7 +287,7 @@ typedef struct __VFlags {
                         format: @"%@ can not initWithCoder:%@", [self class],
                                 [coder class]];
 
-        NSLog(@"NSView version is %d\n", version);
+        NSLog(@"NSView version is %ld\n", (long) version);
 
         union {
             _VFlags vf;
@@ -295,7 +295,7 @@ typedef struct __VFlags {
         } vflags;
 
         vflags.value = 0;
-        NSLog(@"NSView version is %d\n", version);
+        NSLog(@"NSView version is %ld\n", (long) version);
 
         if (version <= 16) {
             float dummy;

--- a/AppKit/include/AppKit/NSWorkspace.h
+++ b/AppKit/include/AppKit/NSWorkspace.h
@@ -127,7 +127,7 @@ typedef NSUInteger NSWorkspaceIconCreationOptions;
 - (NSDictionary *) activeApplication;
 - (void) hideOtherApplications;
 
-- (int) extendPowerOffBy: (int) milliseconds;
+- (NSInteger) extendPowerOffBy: (NSInteger) milliseconds;
 
 - (BOOL) setIcon: (NSImage *) image
          forFile: (NSString *) fullPath

--- a/AppKit/nib.subproj/NSButtonImageSource.m
+++ b/AppKit/nib.subproj/NSButtonImageSource.m
@@ -32,7 +32,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
         _imageName = [[keyed decodeObjectForKey: @"NSImageName"] retain];
     } else {
         NSInteger version = [coder versionForClassName: @"NSButtonImageSource"];
-        NSLog(@"NSButtonImageSource version is %d\n", version);
+        NSLog(@"NSButtonImageSource version is %ld\n", (long) version);
 
         if (version == 1) {
             _imageName = [[coder decodeObject] retain];


### PR DESCRIPTION
Use NSIntegers correctly in formatted strings and comparisons with absolute value. Helps fix #418

Apple's formatted strings guidelines were followed: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html

No regressions on testing with TextEdit.