### PR TITLE
Fix X11 crash for focus events after window is destroyed

### DIFF
--- a/AppKit/X11.backend/X11Display.m
+++ b/AppKit/X11.backend/X11Display.m
@@ -1167,7 +1167,8 @@ static NSDictionary *modeInfoToDictionary(const XRRModeInfo *mi, int depth) {
         }
         [delegate platformWindowActivated: window displayIfNeeded: YES];
         lastFocusedWindow = delegate;
-        XSetICFocus(window->_xic);
+        if (window)
+            XSetICFocus(window->_xic);
         break;
 
     case FocusOut:
@@ -1177,7 +1178,8 @@ static NSDictionary *modeInfoToDictionary(const XRRModeInfo *mi, int depth) {
         lastFocusedWindow = nil;
         if (_cursorGrabbed)
             [self grabMouse: NO];
-        XUnsetICFocus(window->_xic);
+        if (window)
+            XUnsetICFocus(window->_xic);
         break;
 
     case KeymapNotify:


### PR DESCRIPTION
After closing a secondary window shown in the app, AppKit crashed. This was caused by `X11Display` receiving `FocusOut` and `FocusIn` events for the destroyed window, and then using the window pointer without checking if it was valid.

Steps to reproduce the crash:
1. Run the EdenMath app here: http://www.edenwaith.com/products/edenmath/
2. Once the app is running in darling, click the Help Menu -> EdenMath Help
3. On the "Help isn't available" alert window, click the "OK" button
4. Crashes