### PR TITLE
Use localized CFBundleName for NSSystemInfoPanel

### DIFF
--- a/AppKit/NSSystemInfoPanel/NSSystemInfoPanel.m
+++ b/AppKit/NSSystemInfoPanel/NSSystemInfoPanel.m
@@ -53,8 +53,7 @@ static NSSystemInfoPanel *_sharedInfoPanel = nil;
     if (icon != nil)
         [appIconView setImage: icon];
 
-    [appNameField setStringValue: [[[NSBundle mainBundle] infoDictionary]
-                                          objectForKey: @"CFBundleName"]];
+    [appNameField setStringValue: [[NSBundle mainBundle] objectForInfoDictionaryKey: @"CFBundleName"]];
 
     NSString *bundleVersion = [[[NSBundle mainBundle] infoDictionary]
             objectForKey: @"CFBundleVersion"];


### PR DESCRIPTION
This is a bug fix for `NSSystemInfoPanel` to use `objectForInfoDictionaryKey` when fetching the `CFBundleName` in order to get the localized string if it exists. `objectForInfoDictionaryKey` will fallback to the Info.plist if there is no localized string.

The bug could be seen by trying to open the about menu for an app which has `CFBundleName` localized in `InfoPlist.strings` but no value in `Info.plist`, this would cause an exception due to sending a `nil` value to `[NSTextField setStringValue:]`