### PR TITLE
Stubs and symbols for iTerm2

### DIFF
--- a/AppKit/CMakeLists.txt
+++ b/AppKit/CMakeLists.txt
@@ -395,6 +395,7 @@ set(AppKit_sources
 	NSAppearance.m
 	NSAccessibilityElement.m
 	NSKeyValueBinding.m
+	NSCandidateListTouchBarItem.m
 	NSCollectionViewFlowLayout.m
 	NSTouchBarItem.m
 	NSLayoutConstraint.m

--- a/AppKit/CMakeLists.txt
+++ b/AppKit/CMakeLists.txt
@@ -292,6 +292,7 @@ set(AppKit_sources
 	NSPrintProgressPanelController.m
 	NSHelpManager.m
 	NSProgressIndicator.m
+	NSFontCollection.m
 	NSFontDescriptor.m
 	NSDisplay.m
 

--- a/AppKit/CMakeLists.txt
+++ b/AppKit/CMakeLists.txt
@@ -451,6 +451,7 @@ set(AppKit_sources
 	NSSwitch.m
 	NSTextFinder.m
 	NSScrubber.m
+	NSScrubberItemView.m
 	NSUserInterfaceItemIdentification.m
 )
 

--- a/AppKit/NSCandidateListTouchBarItem.m
+++ b/AppKit/NSCandidateListTouchBarItem.m
@@ -1,0 +1,34 @@
+/*
+ This file is part of Darling.
+
+ Copyright (C) 2024 Darling developers
+
+ Darling is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Darling is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#import <AppKit/NSCandidateListTouchBarItem.h>
+
+@implementation NSCandidateListTouchBarItem
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+@end

--- a/AppKit/NSFontCollection.m
+++ b/AppKit/NSFontCollection.m
@@ -1,0 +1,34 @@
+/*
+ This file is part of Darling.
+
+ Copyright (C) 2024 Darling developers
+
+ Darling is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Darling is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#import <AppKit/NSFontCollection.h>
+
+@implementation NSFontCollection
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+@end

--- a/AppKit/NSPasteboard.m
+++ b/AppKit/NSPasteboard.m
@@ -64,6 +64,8 @@ const NSPasteboardName NSFontPboard = @"NSFontPboard";
 const NSPasteboardName NSGeneralPboard = @"NSGeneralPboard";
 const NSPasteboardName NSRulerPboard = @"NSRulerPboard";
 
+const NSPasteboardName NSPasteboardNameFind = @"Apple CFPasteboard find";
+const NSPasteboardName NSPasteboardNameFont = @"Apple CFPasteboard font";
 const NSPasteboardName NSPasteboardNameGeneral = @"Apple CFPasteboard general";
 
 const NSPasteboardReadingOptionKey

--- a/AppKit/NSScrubber.m
+++ b/AppKit/NSScrubber.m
@@ -56,4 +56,16 @@
 
 @end
 
+@implementation NSScrubberSelectionStyle
 
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+@end

--- a/AppKit/NSScrubberItemView.m
+++ b/AppKit/NSScrubberItemView.m
@@ -1,0 +1,62 @@
+/*
+ * This file is part of Darling.
+ *
+ * Copyright (C) 2024 Darling Developers
+ *
+ * Darling is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Darling is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#import <AppKit/NSScrubberItemView.h>
+
+@implementation NSScrubberArrangedView
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+@end
+
+@implementation NSScrubberItemView
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+@end
+
+@implementation NSScrubberTextItemView
+
+- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
+{
+    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
+}
+
+- (void)forwardInvocation:(NSInvocation *)anInvocation
+{
+    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
+}
+
+@end

--- a/AppKit/include/AppKit/AppKit.h
+++ b/AppKit/include/AppKit/AppKit.h
@@ -71,6 +71,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #import <AppKit/NSEvent.h>
 #import <AppKit/NSFileWrapperExtensions.h>
 #import <AppKit/NSFont.h>
+#import <AppKit/NSFontCollection.h>
 #import <AppKit/NSFontDescriptor.h>
 #import <AppKit/NSFontManager.h>
 #import <AppKit/NSFontPanel.h>

--- a/AppKit/include/AppKit/AppKit.h
+++ b/AppKit/include/AppKit/AppKit.h
@@ -39,6 +39,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #import <AppKit/NSButtonCell.h>
 #import <AppKit/NSCIImageRep.h>
 #import <AppKit/NSCachedImageRep.h>
+#import <AppKit/NSCandidateListTouchBarItem.h>
 #import <AppKit/NSCell.h>
 #import <AppKit/NSClickGestureRecognizer.h>
 #import <AppKit/NSClipView.h>

--- a/AppKit/include/AppKit/AppKit.h
+++ b/AppKit/include/AppKit/AppKit.h
@@ -143,6 +143,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #import <AppKit/NSScrollView.h>
 #import <AppKit/NSScroller.h>
 #import <AppKit/NSScrubber.h>
+#import <AppKit/NSScrubberItemView.h>
 #import <AppKit/NSSearchField.h>
 #import <AppKit/NSSearchFieldCell.h>
 #import <AppKit/NSSecureTextField.h>

--- a/AppKit/include/AppKit/NSCandidateListTouchBarItem.h
+++ b/AppKit/include/AppKit/NSCandidateListTouchBarItem.h
@@ -1,0 +1,23 @@
+/*
+ This file is part of Darling.
+
+ Copyright (C) 2024 Darling developers
+
+ Darling is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Darling is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#import <AppKit/NSTouchBarItem.h>
+
+@interface NSCandidateListTouchBarItem<__covariant CandidateType> : NSTouchBarItem
+@end

--- a/AppKit/include/AppKit/NSFontCollection.h
+++ b/AppKit/include/AppKit/NSFontCollection.h
@@ -1,0 +1,23 @@
+/*
+ This file is part of Darling.
+
+ Copyright (C) 2024 Darling developers
+
+ Darling is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Darling is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#import <Foundation/NSObject.h>
+
+@interface NSFontCollection: NSObject <NSCoding, NSCopying, NSMutableCopying>
+@end

--- a/AppKit/include/AppKit/NSPasteboard.h
+++ b/AppKit/include/AppKit/NSPasteboard.h
@@ -66,6 +66,8 @@ APPKIT_EXPORT const NSPasteboardName NSFontPboard;
 APPKIT_EXPORT const NSPasteboardName NSGeneralPboard;
 APPKIT_EXPORT const NSPasteboardName NSRulerPboard;
 
+APPKIT_EXPORT const NSPasteboardName NSPasteboardNameFind;
+APPKIT_EXPORT const NSPasteboardName NSPasteboardNameFont;
 APPKIT_EXPORT const NSPasteboardName NSPasteboardNameGeneral;
 
 typedef NSString *NSPasteboardReadingOptionKey;

--- a/AppKit/include/AppKit/NSScrubber.h
+++ b/AppKit/include/AppKit/NSScrubber.h
@@ -30,3 +30,6 @@
 
 @interface NSScrubberProportionalLayout : NSScrubberLayout
 @end
+
+@interface NSScrubberSelectionStyle : NSObject <NSCoding>
+@end

--- a/AppKit/include/AppKit/NSScrubberItemView.h
+++ b/AppKit/include/AppKit/NSScrubberItemView.h
@@ -1,0 +1,29 @@
+/*
+ * This file is part of Darling.
+ *
+ * Copyright (C) 2024 Darling Developers
+ *
+ * Darling is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Darling is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#import <AppKit/NSView.h>
+
+@interface NSScrubberArrangedView : NSView
+@end
+
+@interface NSScrubberItemView : NSScrubberArrangedView
+@end
+
+@interface NSScrubberTextItemView : NSScrubberItemView
+@end

--- a/CoreData/NSPersistentStoreCoordinator.m
+++ b/CoreData/NSPersistentStoreCoordinator.m
@@ -47,6 +47,7 @@ NSString *const NSInferMappingModelAutomaticallyOption =
         @"NSInferMappingModelAutomaticallyOption";
 NSString *const NSReadOnlyPersistentStoreOption =
         @"NSReadOnlyPersistentStoreOption";
+NSString *const NSSQLiteManualVacuumOption = @"NSSQLiteManualVacuumOption";
 NSString *const NSStoreModelVersionHashesKey =
         @"NSStoreModelVersionHashesKey";
 

--- a/CoreData/include/CoreData/NSPersistentStoreCoordinator.h
+++ b/CoreData/include/CoreData/NSPersistentStoreCoordinator.h
@@ -41,6 +41,7 @@ COREDATA_EXPORT NSString *const NSPersistentStoreSaveConflictsErrorKey;
 
 COREDATA_EXPORT NSString *const NSInferMappingModelAutomaticallyOption;
 COREDATA_EXPORT NSString *const NSReadOnlyPersistentStoreOption;
+COREDATA_EXPORT NSString *const NSSQLiteManualVacuumOption;
 
 @interface NSPersistentStoreCoordinator : NSObject <NSLocking> {
     NSLock *_lock;

--- a/CoreGraphics/CGWindow.m
+++ b/CoreGraphics/CGWindow.m
@@ -22,8 +22,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 const CFStringRef kCGWindowAlpha = CFSTR("kCGWindowAlpha");
 const CFStringRef kCGWindowBounds = CFSTR("kCGWindowBounds");
 const CFStringRef kCGWindowLayer = CFSTR("kCGWindowLayer");
+const CFStringRef kCGWindowOwnerName = CFSTR("kCGWindowOwnerName");
 const CFStringRef kCGWindowOwnerPID = CFSTR("kCGWindowOwnerPID");
 const CFStringRef kCGWindowNumber = CFSTR("kCGWindowNumber");
+const CFStringRef kCGWindowName = CFSTR("kCGWindowName");
 
 @implementation CGWindow
 

--- a/CoreGraphics/include/CoreGraphics/CGWindow.h
+++ b/CoreGraphics/include/CoreGraphics/CGWindow.h
@@ -29,6 +29,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 extern const CFStringRef kCGWindowAlpha;
 extern const CFStringRef kCGWindowBounds;
 extern const CFStringRef kCGWindowLayer;
+extern const CFStringRef kCGWindowName;
+extern const CFStringRef kCGWindowOwnerName;
 extern const CFStringRef kCGWindowOwnerPID;
 
 #ifdef __OBJC__


### PR DESCRIPTION
I attempted to get iTerm2 running under darling, these were the symbols/stubs I needed to implement in Cocotron. While I didn't manage to get iTerm2 fully running, I thought to push these up anyways.

Fixes specific missing symbol mentioned in: https://github.com/darlinghq/darling/issues/1350

### Stubs/Symbols Added
- **AppKit:** NSFontCollection, NSCandidateListTouchBarItem, NSPasteboardNameFind, NSPasteboardNameFont, NSScrubberSelectionStyle, NSScrubberItemView
- **CoreData:** NSSQLiteManualVacuumOption
- **CoreGraphics:** kCGWindowName, kCGWindowOwnerName