### PR TITLE
Implement Unkeyed coder support for SimpleCocoaApp

### DIFF
--- a/AppKit/CMakeLists.txt
+++ b/AppKit/CMakeLists.txt
@@ -302,6 +302,7 @@ set(AppKit_sources
 	# NSOpenGL/NSOpenGLDrawable.m
 	NSOpenGL/NSOpenGLContext.m
 
+	NSMenuItemCell.m
 	NSPopUpButtonCell.m
 	NSPredicateEditor.m
 	NSFont.m

--- a/AppKit/NSBitmapImageRep.m
+++ b/AppKit/NSBitmapImageRep.m
@@ -342,6 +342,27 @@ NSBitmapImageRepPropertyKey NSImageCurrentFrame = @"NSImageCurrentFrame";
     return [self initWithData: data];
 }
 
+- (instancetype) initWithCoder:(NSCoder *) coder {
+    if ([coder allowsKeyedCoding]) {
+        [NSException raise: NSInvalidArgumentException
+                    format: @"-[%@ %s] is not implemented for coder %@",
+                            [self class], sel_getName(_cmd), coder];
+        return nil;
+    } else {
+        NSInteger version = [coder versionForClassName: @"NSImageRep"];
+
+        if (version >= 17) {
+            NSData *data = [coder decodeDataObject];
+            return [self initWithData: data];
+        } else {
+            [NSException raise: NSInvalidArgumentException
+                    format: @"-[%@ %s] is not implemented for coder %@",
+                            [self class], sel_getName(_cmd), coder];
+            return nil;
+        }
+    }
+}
+
 - (void) createBitmapIfNeeded {
     if (_bitmapPlanes == NULL) {
         _freeWhenDone = YES;

--- a/AppKit/NSBox.m
+++ b/AppKit/NSBox.m
@@ -87,9 +87,30 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
             [_customData setObject: obj forKey: @"NSFillColor2"];
         }
     } else {
-        [NSException raise: NSInvalidArgumentException
-                    format: @"%@ can not initWithCoder:%@", [self class],
-                            [coder class]];
+        NSInteger version = [coder versionForClassName: @"NSBox"];
+
+        if (version > 40) {
+            NSView *contentView;
+            float width, height;
+            uint8_t borderType, titlePosition, boxType;
+
+            [coder decodeValuesOfObjCTypes:"ff@@ccc", &width, &height, &_titleCell, &contentView, &borderType, &titlePosition, &boxType];
+
+             // This is already added as a subview in NSView decoding
+            [contentView release];
+
+            _borderType = borderType;
+            _titlePosition = titlePosition;
+            _boxType = boxType;
+
+            _contentViewMargins = CGSizeMake(width, height);
+
+            id object = [coder decodeObject];
+        } else {
+            [NSException raise: NSInvalidArgumentException
+                        format: @"%@ can not initWithCoder:%@", [self class],
+                                [coder class]];
+        }
     }
     return self;
 }

--- a/AppKit/NSButtonCell.m
+++ b/AppKit/NSButtonCell.m
@@ -62,7 +62,7 @@ static const CGFloat kImageMargin = 2.;
               forKey: @"NSButtonCell keyEquivalentModifierMask"];
 }
 
-- _applyButtonCellAppleFlags: (unsigned) flags flags2: (unsigned) flags2 {
+- (void) _applyButtonCellAppleFlags: (unsigned) flags flags2: (unsigned) flags2 {
     _imagePosition = NSNoImage;
     if ((flags & 0x00480000) == 0x00400000)
         _imagePosition = NSImageOnly;
@@ -141,7 +141,7 @@ static const CGFloat kImageMargin = 2.;
         if ([[altImageSource name] isEqualToString: @"NSSwitch"])
             [self setButtonType: NSSwitchButton];
         if ([[altImageSource name] isEqualToString: @"NSRadioButton"])
-            [self setButtonType: NSPushOnPushOffButton];
+            [self setButtonType: NSRadioButton];
     } else {
         if (([[[self image] name] isEqualToString: @"NSRadioButton"] &&
              [[[self alternateImage] name]
@@ -316,7 +316,7 @@ static const CGFloat kImageMargin = 2.;
             [self setKeyEquivalentFont: [coder decodeObject]];
             [self setImage: [coder decodeObject]];
             [self setAlternateImage: [coder decodeObject]];
-            [self setSoundImage: [coder decodeObject]];
+            [self setSound: [coder decodeObject]];
 
             unsigned int var50;
             if (version >= 19)
@@ -342,11 +342,26 @@ static const CGFloat kImageMargin = 2.;
             flags2 &= 0xFFFFFFD8;
         } else {
             short periodicDelay, periodicInterval;
+            id alternateImageOrFont;
             [coder decodeValuesOfObjCTypes: "ssii@@@@@", &periodicDelay,
                                             &periodicInterval, &flags2, &flags,
                                             &_alternateTitle, &_keyEquivalent,
-                                            &_normalImage, &_alternateImage,
+                                            &_normalImage, &alternateImageOrFont,
                                             &_sound];
+
+            if ([alternateImageOrFont isKindOfClass:[NSButtonImageSource class]]) {
+                _alternateImage = alternateImageOrFont;
+            } else if ([alternateImageOrFont isKindOfClass:[NSFont class]]) {
+                _keyEquivalentFont = alternateImageOrFont;
+            } else {
+                [alternateImageOrFont release];
+            }
+
+            // Title is in the _objectValue decoded in NSCell
+            NSString* stringValue = [self stringValue];
+            if ([stringValue length] > 0) {
+                [self setTitle: stringValue];
+            }
 
             [self setPeriodicDelay: periodicDelay / 1000.0f
                           interval: periodicInterval / 1000.0f];

--- a/AppKit/NSCell.m
+++ b/AppKit/NSCell.m
@@ -363,7 +363,7 @@ typedef NS_OPTIONS(unsigned int, NSCellAppleFlags2) {
 
 - initTextCell: (NSString *) string {
     _focusRingType = [[self class] defaultFocusRingType];
-    _state = NSOffState;
+    _state = NSControlStateValueOff;
     _font = [[NSFont userFontOfSize: 0] retain];
     _objectValue = [string copy];
     _image = nil;
@@ -382,7 +382,7 @@ typedef NS_OPTIONS(unsigned int, NSCellAppleFlags2) {
 
 - initImageCell: (NSImage *) image {
     _focusRingType = [[self class] defaultFocusRingType];
-    _state = NSOffState;
+    _state = NSControlStateValueOff;
     _font = nil;
     _objectValue = nil;
     _image = [image retain];

--- a/AppKit/NSFont.m
+++ b/AppKit/NSFont.m
@@ -438,7 +438,7 @@ static NSLock *_cacheLock = nil;
 
     NSLog(@"NSFont decoding done\n");
 
-    [self dealloc];
+    [self release];
     NSFont *realFont = [[NSFont fontWithName: name size: size] retain];
 
     O2FontLog(@"coded font name: %@ translated font name: %@ rendered font: %@",

--- a/AppKit/NSImage.m
+++ b/AppKit/NSImage.m
@@ -401,11 +401,44 @@ NSImageName const NSImageNameTouchBarVolumeUpTemplate =
 
         [_representations addObject: rep];
     } else {
-        [NSException raise: NSInvalidArgumentException
+        NSInteger version = [coder versionForClassName: @"NSImage"];
+
+        if (version >= 17) {
+            _name = [[coder decodeObject] retain];
+
+            NSUnarchiver *unarchiver = (NSUnarchiver *)coder;
+
+            uint8_t byteOne = [unarchiver decodeByte];
+            uint8_t byteTwo = [unarchiver decodeByte];
+
+            // TODO: There's some logic involving these decoded
+            // bytes and the internal _flags of NSImage to determine
+            // decoding the rest of these.
+
+            for (int i = 0; i < 12; ++i) {
+                uint8_t btye = [unarchiver decodeByte];
+            }
+
+            _size = [coder decodeSize];
+
+            short shortValue;
+            [coder decodeValueOfObjCType:"s" at: &shortValue];
+
+            uint8_t anotherBtye = [unarchiver decodeByte];
+
+            NSBitmapImageRep *rep = [coder decodeObject];
+            _representations = [NSMutableArray new];
+            [_representations addObject: rep];
+
+            _backgroundColor = [[coder decodeObject] retain];
+            _delegate = [coder decodeObject];
+        } else {
+            [NSException raise: NSInvalidArgumentException
                     format: @"-[%@ %s] is not implemented for coder %@",
                             [self class], sel_getName(_cmd), coder];
+        }
     }
-    return nil;
+    return self;
 }
 
 - initWithSize: (NSSize) size {

--- a/AppKit/NSImageRep.m
+++ b/AppKit/NSImageRep.m
@@ -247,6 +247,14 @@ static NSMutableArray *_registeredClasses = nil;
     return nil;
 }
 
+- (instancetype) initWithCoder:(NSCoder *) coder
+{
+    [NSException raise: NSInvalidArgumentException
+                    format: @"-[%@ %s] is not implemented for coder %@",
+                            [self class], sel_getName(_cmd), coder];
+    return nil;
+}
+
 - copyWithZone: (NSZone *) zone {
     NSImageRep *result = NSCopyObject(self, 0, zone);
     result->_colorSpaceName = [_colorSpaceName copy];

--- a/AppKit/NSMenu.subproj/NSMenu.m
+++ b/AppKit/NSMenu.subproj/NSMenu.m
@@ -141,9 +141,7 @@ NSString *const _NSWindowsMenuName = @"Window";
         } else {
             int flags;
 
-            [coder decodeValueOfObjCType: @encode(int) at: &flags];
-
-            [coder decodeValuesOfObjCTypes: "@@@", &_title, &_itemArray,
+            [coder decodeValuesOfObjCTypes: "i@@@", &flags, &_title, &_itemArray,
                                             &_name];
 
             _autoenablesItems = !(flags & 0x80000000);

--- a/AppKit/NSMenu.subproj/NSMenuItem.m
+++ b/AppKit/NSMenu.subproj/NSMenuItem.m
@@ -440,17 +440,3 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 }
 
 @end
-
-@implementation NSMenuItemCell
-
-- (NSMethodSignature *)methodSignatureForSelector:(SEL)aSelector
-{
-    return [NSMethodSignature signatureWithObjCTypes: "v@:"];
-}
-
-- (void)forwardInvocation:(NSInvocation *)anInvocation
-{
-    NSLog(@"Stub called: %@ in %@", NSStringFromSelector([anInvocation selector]), [self class]);
-}
-
-@end

--- a/AppKit/NSMenu.subproj/NSMenuItem.m
+++ b/AppKit/NSMenu.subproj/NSMenuItem.m
@@ -76,9 +76,42 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
             _title = nil;
         }
     } else {
-        [NSException raise: NSInvalidArgumentException
-                    format: @"%@ can not initWithCoder:%@", [self class],
-                            [coder class]];
+        NSInteger version = [coder versionForClassName: @"NSMenuItem"];
+
+        if (version == NSNotFound) {
+            version = [coder versionForClassName: @"NSMenuCell"];
+        }
+
+        _menu = [coder decodeObject];
+
+        int flags;
+
+        // TODO: Figure this out, encodeWithCoder is writing this as 0xffffffffffffffff
+        unsigned int unused;
+
+        [coder decodeValuesOfObjCTypes:"i@@IIi@@@@:i@", &flags, &_title, &_keyEquivalent, &_keyEquivalentModifierMask, &unused, &_state, &_image, &_onStateImage, &_mixedStateImage, &_offStateImage, &_action, &_tag, &_representedObject];
+
+
+        // If we have an empty title, it is for a separator, discard it, see isSeparatorItem
+        if (_title && [_title length] == 0) {
+            [_title release];
+            _title = nil;
+        }
+
+        if (version <= 320) {
+            if (_action != @selector(submenuAction:)) {
+                _target = [coder decodeObject];
+            } else {
+                _submenu = [[coder decodeObject] retain];
+            }
+        } else {
+            _target = [coder decodeObject];
+            _submenu = [[coder decodeObject] retain];
+        }
+
+        // Set other default values from [initWithTitle: action: keyEquivalent:]
+        _mnemonic = @"";
+        _enabled = YES;
     }
 
     return self;

--- a/AppKit/NSMenuItemCell.m
+++ b/AppKit/NSMenuItemCell.m
@@ -1,0 +1,57 @@
+/*
+ * This file is part of Darling.
+ *
+ * Copyright (C) 2024 Darling Developers
+ *
+ * Darling is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Darling is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ #import <AppKit/NSMenuItemCell.h>
+
+ @implementation NSMenuItemCell
+
+ @synthesize menuItem = _menuItem;
+
+ - initWithCoder: (NSCoder *) coder {
+    self = [super initWithCoder: coder];
+
+    if ([coder allowsKeyedCoding]) {
+        _menuItem = [[coder decodeObjectForKey:@"NSMenuItem"] retain];
+    } else {
+        NSInteger version = [coder versionForClassName: @"NSMenuItemCell"];
+
+        if (version >= 207) {
+            id object;
+            [coder decodeValuesOfObjCTypes:"@@", &_menuItem, &object];
+
+            // Discard for now
+            [object release];
+
+            if (version <= 209) {
+                [self setBordered: NO];
+            }
+        } else {
+            [self setBordered: NO];
+        }
+    }
+
+    return self;
+ }
+
+ - (void) dealloc {
+    [_menuItem release];
+    [super dealloc];
+}
+
+ @end

--- a/AppKit/NSTextField.m
+++ b/AppKit/NSTextField.m
@@ -73,7 +73,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
         if (version < 25) {
             [self setNextKeyView: [coder decodeObject]];
-            [self setNextKeyView: [coder decodeObject]];
+            [[coder decodeObject] setNextKeyView: self];
         }
 
         [self setDelegate: [coder decodeObject]];

--- a/AppKit/NSView.m
+++ b/AppKit/NSView.m
@@ -363,14 +363,18 @@ typedef struct __VFlags {
 
             vflags.value = flags & 0xFFC00000;
 
-            id dummy, frameMatrix;
+            id drawMatrix, frameMatrix;
 
             float fx, fy, fw, fh;
             float bx, by, bw, bh;
-            [coder decodeValuesOfObjCTypes: "@@@@ffffffff", &_draggedTypes,
-                                            &_subviews, &dummy, &frameMatrix,
+            [coder decodeValuesOfObjCTypes: "@@@@ffffffff", &_subviews,
+                                            &drawMatrix, &frameMatrix, &_draggedTypes,
                                             &fx, &fy, &fw, &fh, &bx, &by, &bx,
                                             &bh];
+
+            // Discard for now
+            [drawMatrix release];
+            [frameMatrix release];
 
             _frame = NSMakeRect(fx, fy, fw, fh);
             _bounds = NSMakeRect(bx, by, bw, bh);
@@ -378,7 +382,7 @@ typedef struct __VFlags {
             _superview = [coder decodeObject];
             _window = [coder decodeObject];
             [self setNextKeyView: [coder decodeObject]];
-            dummy = [coder decodeObject];
+            id dummy = [coder decodeObject];
         }
 
         _autoresizingMask = vflags.vf.autosizing;

--- a/AppKit/NSView.m
+++ b/AppKit/NSView.m
@@ -369,7 +369,7 @@ typedef struct __VFlags {
             float bx, by, bw, bh;
             [coder decodeValuesOfObjCTypes: "@@@@ffffffff", &_subviews,
                                             &drawMatrix, &frameMatrix, &_draggedTypes,
-                                            &fx, &fy, &fw, &fh, &bx, &by, &bx,
+                                            &fx, &fy, &fw, &fh, &bx, &by, &bw,
                                             &bh];
 
             // Discard for now

--- a/AppKit/include/AppKit/NSImageRep.h
+++ b/AppKit/include/AppKit/NSImageRep.h
@@ -56,6 +56,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 + imageRepWithContentsOfURL: (NSURL *) url;
 + imageRepWithPasteboard: (NSPasteboard *) pasteboard;
 
+- (instancetype) initWithCoder:(NSCoder *) coder;
+
 - (NSSize) size;
 - (int) pixelsWide;
 - (int) pixelsHigh;

--- a/AppKit/include/AppKit/NSMenuItemCell.h
+++ b/AppKit/include/AppKit/NSMenuItemCell.h
@@ -1,0 +1,31 @@
+/*
+ * This file is part of Darling.
+ *
+ * Copyright (C) 2024 Darling Developers
+ *
+ * Darling is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Darling is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Darling.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#import <AppKit/NSButtonCell.h>
+
+@class NSMenuItem;
+
+@interface NSMenuItemCell : NSButtonCell  {
+    // In Apple's AppKit this is stored in _extraData (NSExtraMICData)
+    NSMenuItem *_menuItem;
+ }
+
+@property(retain) NSMenuItem *menuItem;
+
+@end

--- a/AppKit/include/AppKit/NSPopUpButtonCell.h
+++ b/AppKit/include/AppKit/NSPopUpButtonCell.h
@@ -17,7 +17,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
-#import <AppKit/NSButtonCell.h>
+#import <AppKit/NSMenuItemCell.h>
 
 @class NSMenuItem;
 
@@ -27,7 +27,7 @@ typedef enum {
     NSPopUpArrowAtBottom = 2
 } NSPopUpArrowPosition;
 
-@interface NSPopUpButtonCell : NSButtonCell {
+@interface NSPopUpButtonCell : NSMenuItemCell {
     NSMenu *_menu;
     NSInteger _selectedIndex;
     BOOL _pullsDown;
@@ -35,6 +35,7 @@ typedef enum {
     BOOL _usesItemFromMenu;
     NSPopUpArrowPosition _arrowPosition;
     NSRectEdge _preferredEdge;
+    BOOL _syncTitleNeeded;
 }
 
 - initTextCell: (NSString *) string pullsDown: (BOOL) pullDown;

--- a/AppKit/nib.subproj/NSCustomResource.m
+++ b/AppKit/nib.subproj/NSCustomResource.m
@@ -31,10 +31,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 
         _className = [[keyed decodeObjectForKey: @"NSClassName"] retain];
         _resourceName = [[keyed decodeObjectForKey: @"NSResourceName"] retain];
-    } else
-        [NSException raise: NSInvalidArgumentException
-                    format: @"-[%@ %s] can not decode from a %@", [self class],
-                            sel_getName(_cmd), [coder class]];
+    } else {
+        [coder decodeValuesOfObjCTypes:"@@", &_className, &_resourceName];
+    }
 
     return self;
 }

--- a/AppKit/nib.subproj/NSIBObjectData.h
+++ b/AppKit/nib.subproj/NSIBObjectData.h
@@ -35,6 +35,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
     NSMutableSet *_visibleWindows;
     id _firstResponder;
     BOOL _shouldEncodeDesigntimeData;
+    NSMapTable *_instantiatedObjectTable;
 }
 
 @property(copy) NSString *targetFramework;

--- a/AppKit/nib.subproj/NSIBObjectData.m
+++ b/AppKit/nib.subproj/NSIBObjectData.m
@@ -535,7 +535,8 @@ NSString *const IBCocoaFramework = @"IBCocoaFramework";
         id formerOwner = [_fileOwner autorelease];
         _fileOwner = [owner retain];
 
-        for (id aKey in _objectTable) {
+        NSArray *keys = NSAllMapTableKeys(_objectTable);
+        for (id aKey in keys) {
             id aValue = [_objectTable objectForKey: aKey];
             if (aValue == formerOwner) {
                 [_objectTable setObject: _fileOwner forKey: aKey];

--- a/AppKit/nib.subproj/NSIBObjectData.m
+++ b/AppKit/nib.subproj/NSIBObjectData.m
@@ -364,6 +364,23 @@ NSString *const IBCocoaFramework = @"IBCocoaFramework";
                 [coder decodeValueOfObjCType: @encode(int) at: &nextOid];
                 _nextOid = nextOid;
             }
+
+            if (version > 23) {
+                [coder decodeValueOfObjCType: @encode(int) at: &count];
+
+                for (int i = 0; i < count; i++) {
+                    NSObject *key, *value;
+
+                    [coder decodeValuesOfObjCTypes: "@@", &key, &value];
+                    NSMapInsert(_instantiatedObjectTable, key, value);
+                }
+            }
+
+            if (version <= 223) {
+                _framework = [IBCocoaFramework copy];
+            } else {
+                _framework = [[coder decodeObject] retain];
+            }
         }
 
         if (!NSMapMember(_oidTable, _fileOwner, NULL, NULL)) {

--- a/AppKit/nib.subproj/NSNibConnector.m
+++ b/AppKit/nib.subproj/NSNibConnector.m
@@ -42,9 +42,15 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
         _destination = [[keyed decodeObjectForKey: @"NSDestination"] retain];
         _label = [[keyed decodeObjectForKey: @"NSLabel"] retain];
     } else {
-        [NSException raise: NSInvalidArgumentException
-                    format: @"-[%@ %s] is not implemented for coder %@",
-                            [self class], sel_getName(_cmd), coder];
+        NSInteger version = [coder versionForClassName: @"NSNibConnector"];
+
+        if (version > 10) {
+            [coder decodeValuesOfObjCTypes:"@@@", &_source, &_destination, &_label];
+        } else {
+            [NSException raise: NSInvalidArgumentException
+                        format: @"-[%@ %s] is not implemented for coder %@",
+                                [self class], sel_getName(_cmd), coder];
+        }
     }
     return self;
 }

--- a/AppKit/nib.subproj/NSWindowTemplate.h
+++ b/AppKit/nib.subproj/NSWindowTemplate.h
@@ -53,6 +53,7 @@ typedef NS_OPTIONS(uint32_t, NSWindowTemplateFlags) {
     NSSize _contentMaxSize;
     NSRect screenRect;
     id _viewClass;
+    id _extension;
     NSWindowTemplateFlags _wtFlags;
     NSInteger _windowBacking;
     NSString *_windowClass;


### PR DESCRIPTION
This PR implements unkeyed coder support for many AppKit classes in order to run Apple's [SimpleCocoaApp](https://developer.apple.com/library/archive/samplecode/SimpleCocoaApp/Introduction/Intro.html#//apple_ref/doc/uid/DTS10000403), which uses unkeyed coder.

- This fixes https://github.com/darlinghq/darling/issues/1490.
- The changes should be reviewed by each commit.
- This [PR](https://github.com/darlinghq/darling-foundation/pull/16) for Foundation is required in order for this PR to work.

**Note:** Some of the `initWithCoder` have TODO messages where I didn't fully implement handling the decoded values or fully implement the decoding logic to match Apple's. What I have implemented works for the SimpleCocoaApp, but may not work fully for other apps using unkeyed coding.

### Screenshot
![Screenshot from 2025-01-03 13-34-51](https://github.com/user-attachments/assets/a98538af-e9dd-481f-864c-6a362e3a7ce9)
