### PR TITLE
several missing symbols

### DIFF
--- a/AppKit/NSFontDescriptor.m
+++ b/AppKit/NSFontDescriptor.m
@@ -41,6 +41,9 @@ NSString *const NSFontWeightTrait = @"NSFontWeightTrait";
 NSString *const NSFontWidthTrait = @"NSFontWidthTrait";
 NSString *const NSFontSlantTrait = @"NSFontSlantTrait";
 
+NSString *const NSFontFeatureSelectorIdentifierKey = @"CTFeatureSelectorIdentifier";
+NSString *const NSFontFeatureTypeIdentifierKey = @"CTFeatureTypeIdentifier";
+
 const NSFontWeight NSFontWeightThin = 0xbfe3333340000000;
 const NSFontWeight NSFontWeightLight = 0xbfd99999a0000000;
 const NSFontWeight NSFontWeightUltraLight = 0xbfe99999a0000000;


### PR DESCRIPTION
taking ownership of #13 , since it's been untouched for a very long time, and I have the resources to get the actual values via https://github.com/darlinghq/darling/issues/1588#issuecomment-2881818092.

I've already rebased their branch on master, removed duplicates (symbols already in the master branch) and squashed, but I still need to get the actual values for

- [x] `NSFontFeatureSelectorIdentifierKey` should be `CTFeatureSelectorIdentifier`
- [x] `NSFontFeatureTypeIdentifierKey` should be `CTFeatureTypeIdentifier`
- [x] `kCGFontNameKeyCopyright` doesn't seem to exist?
- [x] `kCGFontNameKeyFontFamily` doesn't seem to exist?
- [x] `kCGFontNameKeyFontSubfamily` doesn't seem to exist?
- [x] `kCGFontNameKeyFullName` doesn't seem to exist?
- [x] `kCGFontNameKeyPostScriptName` doesn't seem to exist?
- [x] `kCGFontNameKeyPreferredFamily` doesn't seem to exist?
- [x] `kCGFontNameKeyPreferredSubfamily` doesn't seem to exist?
- [x] `kCGFontNameKeyVersion` doesn't seem to exist?

I also need to

- [x] build this code

but I don't know which apps to test this on.

---

missing symbols required by MorxTester

fixes https://github.com/darlinghq/darling/issues/801

missing symbols required by fontworker,fontmover,FontRegistryUIAgent

no longer does anything about https://github.com/darlinghq/darling/issues/805

more missing symbols required by MorxTester

more symbols required by fontworker