### PR TITLE
Add symbols for SubEthaEdit app

### DIFF
--- a/AppKit/NSFontDescriptor.m
+++ b/AppKit/NSFontDescriptor.m
@@ -16,33 +16,47 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
+
 #import <AppKit/NSFontDescriptor.h>
 #import <AppKit/NSRaise.h>
 #import <Foundation/NSDictionary.h>
 #import <Foundation/NSString.h>
 #import <Foundation/NSValue.h>
 
-NSString *const NSFontNameAttribute = @"NSFontNameAttribute";
-NSString *const NSFontFamilyAttribute = @"NSFontFamilyAttribute";
-NSString *const NSFontSizeAttribute = @"NSFontSizeAttribute";
-NSString *const NSFontMatrixAttribute = @"NSFontMatrixAttribute";
-NSString *const NSFontCharacterSetAttribute = @"NSFontCharacterSetAttribute";
-NSString *const NSFontTraitsAttribute = @"NSFontTraitsAttribute";
-NSString *const NSFontFaceAttribute = @"NSFontFaceAttribute";
-NSString *const NSFontFixedAdvanceAttribute = @"NSFontFixedAdvanceAttribute";
-NSString *const NSFontVisibleNameAttribute = @"NSFontVisibleNameAttribute";
-NSString *const NSFontCascadeListAttribute = @"NSCTFontCascadeListAttribute";
-NSString *const NSFontFeatureSettingsAttribute =
+NSFontDescriptorAttributeName const NSFontFamilyAttribute =
+        @"NSFontFamilyAttribute";
+NSFontDescriptorAttributeName const NSFontNameAttribute =
+        @"NSFontNameAttribute";
+NSFontDescriptorAttributeName const NSFontFaceAttribute =
+        @"NSFontFaceAttribute";
+NSFontDescriptorAttributeName const NSFontSizeAttribute =
+        @"NSFontSizeAttribute";
+NSFontDescriptorAttributeName const NSFontVisibleNameAttribute =
+        @"NSFontVisibleNameAttribute";
+NSFontDescriptorAttributeName const NSFontMatrixAttribute =
+        @"NSFontMatrixAttribute";
+NSFontDescriptorAttributeName const NSFontVariationAttribute =
+        @"NSCTFontVariationAttribute";
+NSFontDescriptorAttributeName const NSFontCharacterSetAttribute =
+        @"NSFontCharacterSetAttribute";
+NSFontDescriptorAttributeName const NSFontCascadeListAttribute =
+        @"NSCTFontCascadeListAttribute";
+NSFontDescriptorAttributeName const NSFontTraitsAttribute =
+        @"NSFontTraitsAttribute";
+NSFontDescriptorAttributeName const NSFontFixedAdvanceAttribute =
+        @"NSFontFixedAdvanceAttribute";
+NSFontDescriptorAttributeName const NSFontFeatureSettingsAttribute =
         @"NSCTFontFeatureSettingsAttribute";
-NSString *const NSFontVariationAttribute = @"NSCTFontVariationAttribute";
 
-NSString *const NSFontSymbolicTrait = @"NSFontSymbolicTrait";
-NSString *const NSFontWeightTrait = @"NSFontWeightTrait";
-NSString *const NSFontWidthTrait = @"NSFontWidthTrait";
-NSString *const NSFontSlantTrait = @"NSFontSlantTrait";
+NSFontDescriptorFeatureKey const NSFontFeatureSelectorIdentifierKey =
+        @"CTFeatureSelectorIdentifier";
+NSFontDescriptorFeatureKey const NSFontFeatureTypeIdentifierKey =
+        @"CTFeatureTypeIdentifier";
 
-NSString *const NSFontFeatureSelectorIdentifierKey = @"CTFeatureSelectorIdentifier";
-NSString *const NSFontFeatureTypeIdentifierKey = @"CTFeatureTypeIdentifier";
+NSFontDescriptorTraitKey const NSFontSymbolicTrait = @"NSFontSymbolicTrait";
+NSFontDescriptorTraitKey const NSFontWeightTrait = @"NSFontWeightTrait";
+NSFontDescriptorTraitKey const NSFontWidthTrait = @"NSFontWidthTrait";
+NSFontDescriptorTraitKey const NSFontSlantTrait = @"NSFontSlantTrait";
 
 const NSFontWeight NSFontWeightThin = 0xbfe3333340000000;
 const NSFontWeight NSFontWeightLight = 0xbfd99999a0000000;

--- a/AppKit/NSPopover.m
+++ b/AppKit/NSPopover.m
@@ -1,11 +1,12 @@
 #import <Foundation/NSObject.h>
 
-// DUMMY
-const NSString *NSPopoverDidCloseNotification =
+const NSNotificationName NSPopoverDidCloseNotification =
         @"NSPopoverDidCloseNotification";
-const NSString *NSPopoverWillCloseNotification =
+const NSNotificationName NSPopoverWillCloseNotification =
         @"NSPopoverWillCloseNotification";
-const NSString *NSPopoverDidShowNotification =
+const NSNotificationName NSPopoverWillShowNotification =
+        @"NSPopoverWillShowNotification";
+const NSNotificationName NSPopoverDidShowNotification =
         @"NSPopoverDidShowNotification";
 
 @interface NSPopover : NSObject

--- a/AppKit/NSPrintInfo.m
+++ b/AppKit/NSPrintInfo.m
@@ -24,41 +24,44 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #import <Foundation/NSThread.h>
 #import <Foundation/NSValue.h>
 
-NSString *const NSPrintPrinter = @"NSPrintPrinter";
-NSString *const NSPrintPrinterName = @"NSPrintPrinterName";
-NSString *const NSPrintJobDisposition = @"NSPrintJobDisposition";
-NSString *const NSPrintDetailedErrorReporting =
-        @"NSPrintDetailedErrorReporting";
+NSPrintInfoAttributeKey const NSPrintPaperName = @"NSPrintPaperName";
+NSPrintInfoAttributeKey const NSPrintPaperSize = @"NSPrintPaperSize";
+NSPrintInfoAttributeKey const NSPrintOrientation = @"NSPrintOrientation";
 
-NSString *const NSPrintSpoolJob = @"NSPrintSpoolJob";
-NSString *const NSPrintPreviewJob = @"NSPrintPreviewJob";
-NSString *const NSPrintSaveJob = @"NSPrintSaveJob";
-NSString *const NSPrintCancelJob = @"NSPrintCancelJob";
+NSPrintInfoAttributeKey const NSPrintLeftMargin = @"NSPrintLeftMargin";
+NSPrintInfoAttributeKey const NSPrintRightMargin = @"NSPrintRightMargin";
+NSPrintInfoAttributeKey const NSPrintTopMargin = @"NSPrintTopMargin";
+NSPrintInfoAttributeKey const NSPrintBottomMargin = @"NSPrintBottomMargin";
+NSPrintInfoAttributeKey const NSPrintHorizontallyCentered =
+        @"NSPrintHorizontallyCentered";
+NSPrintInfoAttributeKey const NSPrintVerticallyCentered =
+        @"NSPrintVerticallyCentered";
+NSPrintInfoAttributeKey const NSPrintHorizontalPagination =
+        @"NSPrintHorizontalPagination";
+NSPrintInfoAttributeKey const NSPrintVerticalPagination =
+        @"NSPrintVerticalPagination";
+
+NSPrintInfoAttributeKey const NSPrintAllPages = @"NSPrintAllPages";
+NSPrintInfoAttributeKey const NSPrintCopies = @"NSPrintCopies";
+NSPrintInfoAttributeKey const NSPrintDetailedErrorReporting =
+        @"NSPrintDetailedErrorReporting";
+NSPrintInfoAttributeKey const NSPrintFirstPage = @"NSPrintFirstPage";
+NSPrintInfoAttributeKey const NSPrintHeaderAndFooter =
+        @"NSPrintHeaderAndFooter";
+NSPrintInfoAttributeKey const NSPrintJobDisposition = @"NSPrintJobDisposition";
+NSPrintInfoAttributeKey const NSPrintJobSavingURL = @"NSJobSavingURL";
+NSPrintInfoAttributeKey const NSPrintLastPage = @"NSPrintLastPage";
+NSPrintInfoAttributeKey const NSPrintMustCollate = @"NSPrintMustCollate";
+NSPrintInfoAttributeKey const NSPrintPrinter = @"NSPrintPrinter";
+NSPrintInfoAttributeKey const NSPrintPrinterName = @"NSPrintPrinterName";
+NSPrintInfoAttributeKey const NSPrintSelectionOnly = @"NSPrintSelectionOnly";
+
+NSPrintJobDispositionValue const NSPrintSpoolJob = @"NSPrintSpoolJob";
+NSPrintJobDispositionValue const NSPrintPreviewJob = @"NSPrintPreviewJob";
+NSPrintJobDispositionValue const NSPrintSaveJob = @"NSPrintSaveJob";
+NSPrintJobDispositionValue const NSPrintCancelJob = @"NSPrintCancelJob";
 
 NSString *const NSPrintSavePath = @"NSPrintSavePath";
-
-NSString *const NSPrintCopies = @"NSPrintCopies";
-NSString *const NSPrintAllPages = @"NSPrintAllPages";
-NSString *const NSPrintFirstPage = @"NSPrintFirstPage";
-NSString *const NSPrintLastPage = @"NSPrintLastPage";
-
-NSString *const NSPrintPaperName = @"NSPrintPaperName";
-NSString *const NSPrintPaperSize = @"NSPrintPaperSize";
-NSString *const NSPrintOrientation = @"NSPrintOrientation";
-
-NSString *const NSPrintHorizontalPagination = @"NSPrintHorizontalPagination";
-NSString *const NSPrintVerticalPagination = @"NSPrintVerticalPagination";
-
-NSString *const NSPrintTopMargin = @"NSPrintTopMargin";
-NSString *const NSPrintBottomMargin = @"NSPrintBottomMargin";
-NSString *const NSPrintLeftMargin = @"NSPrintLeftMargin";
-NSString *const NSPrintRightMargin = @"NSPrintRightMargin";
-NSString *const NSPrintHorizontallyCentered = @"NSPrintHorizontallyCentered";
-NSString *const NSPrintVerticallyCentered = @"NSPrintVerticallyCentered";
-
-NSString *const NSPrintHeaderAndFooter = @"NSPrintHeaderAndFooter";
-NSString *const NSPrintMustCollate = @"NSPrintMustCollate";
-NSString *const NSPrintSelectionOnly = @"NSPrintSelectionOnly";
 
 const NSPrintingPaginationMode NSFitPagination = NSPrintingPaginationModeFit;
 const NSPrintingPaginationMode NSAutoPagination =

--- a/AppKit/NSSharingService.m
+++ b/AppKit/NSSharingService.m
@@ -1,6 +1,22 @@
 #import <AppKit/NSSharingService.h>
 
-NSString* const NSSharingServiceNameComposeEmail = @"NSSharingServiceNameComposeEmail";
+NSSharingServiceName const NSSharingServiceNameAddToIPhoto =
+        @"com.apple.share.System.add-to-iphoto";
+NSSharingServiceName const NSSharingServiceNameComposeEmail =
+        @"NSSharingServiceNameComposeEmail";
+NSSharingServiceName const NSSharingServiceNameComposeMessage =
+        @"com.apple.messages.ShareExtension";
+
+NSSharingServiceName const NSSharingServiceNamePostOnFacebook =
+        @"com.apple.share.Facebook.post";
+NSSharingServiceName const NSSharingServiceNamePostOnTwitter =
+        @"com.apple.share.Twitter.post";
+NSSharingServiceName const NSSharingServiceNamePostOnSinaWeibo =
+        @"com.apple.share.SinaWeibo.post";
+NSSharingServiceName const NSSharingServiceNamePostOnTencentWeibo =
+        @"com.apple.share.TencentWeibo.post";
+NSSharingServiceName const NSSharingServiceNamePostOnLinkedIn =
+        @"com.apple.share.LinkedIn.post";
 
 @implementation NSSharingService
 

--- a/AppKit/include/AppKit/NSFontDescriptor.h
+++ b/AppKit/include/AppKit/NSFontDescriptor.h
@@ -16,30 +16,39 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
+
 #import <AppKit/AppKitExport.h>
 #import <Foundation/NSObject.h>
 
 @class NSDictionary, NSAffineTransform, NSArray, NSSet;
 
-APPKIT_EXPORT NSString *const NSFontNameAttribute;
-APPKIT_EXPORT NSString *const NSFontFamilyAttribute;
-APPKIT_EXPORT NSString *const NSFontSizeAttribute;
-APPKIT_EXPORT NSString *const NSFontMatrixAttribute;
-APPKIT_EXPORT NSString *const NSFontCharacterSetAttribute;
-APPKIT_EXPORT NSString *const NSFontTraitsAttribute;
-APPKIT_EXPORT NSString *const NSFontFaceAttribute;
-APPKIT_EXPORT NSString *const NSFontFixedAdvanceAttribute;
-APPKIT_EXPORT NSString *const NSFontVisibleNameAttribute;
-APPKIT_EXPORT NSString *const NSFontCascadeListAttribute;
-APPKIT_EXPORT NSString *const NSFontFeatureSettingsAttribute;
-APPKIT_EXPORT NSString *const NSFontVariationAttribute;
+typedef NSString *NSFontDescriptorAttributeName;
+
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontFamilyAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontNameAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontFaceAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontSizeAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontVisibleNameAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontMatrixAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontVariationAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontCharacterSetAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontCascadeListAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontTraitsAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontFixedAdvanceAttribute;
+APPKIT_EXPORT NSFontDescriptorAttributeName const NSFontFeatureSettingsAttribute;
+
+typedef NSString *NSFontDescriptorFeatureKey;
+
+APPKIT_EXPORT NSFontDescriptorFeatureKey const NSFontFeatureTypeIdentifierKey;
+APPKIT_EXPORT NSFontDescriptorFeatureKey const NSFontFeatureSelectorIdentifierKey;
 
 typedef unsigned NSFontSymbolicTraits;
+typedef NSString *NSFontDescriptorTraitKey;
 
-APPKIT_EXPORT NSString *const NSFontSymbolicTrait;
-APPKIT_EXPORT NSString *const NSFontWeightTrait;
-APPKIT_EXPORT NSString *const NSFontWidthTrait;
-APPKIT_EXPORT NSString *const NSFontSlantTrait;
+APPKIT_EXPORT NSFontDescriptorTraitKey const NSFontSymbolicTrait;
+APPKIT_EXPORT NSFontDescriptorTraitKey const NSFontWeightTrait;
+APPKIT_EXPORT NSFontDescriptorTraitKey const NSFontWidthTrait;
+APPKIT_EXPORT NSFontDescriptorTraitKey const NSFontSlantTrait;
 
 typedef CGFloat NSFontWeight;
 

--- a/AppKit/include/AppKit/NSPopover.h
+++ b/AppKit/include/AppKit/NSPopover.h
@@ -1,4 +1,8 @@
+#import <AppKit/AppKitExport.h>
+#import <Foundation/NSNotification.h>
 #import <Foundation/NSObject.h>
+
+APPKIT_EXPORT NSNotificationName NSPopoverWillShowNotification;
 
 @protocol NSPopoverDelegate <NSObject>
 

--- a/AppKit/include/AppKit/NSPrintInfo.h
+++ b/AppKit/include/AppKit/NSPrintInfo.h
@@ -26,8 +26,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 typedef enum NSPrintingPaginationMode : int {
     NSPrintingPaginationModeAutomatic,
     NSPrintingPaginationModeFit,
-    NSPrintingPaginationModeClip
-
+    NSPrintingPaginationModeClip,
 } NSPrintingPaginationMode;
 
 APPKIT_EXPORT const NSPrintingPaginationMode NSFitPagination;
@@ -39,40 +38,45 @@ typedef enum {
     NSLandscapeOrientation,
 } NSPrintingOrientation;
 
-APPKIT_EXPORT NSString *const NSPrintPrinter;
-APPKIT_EXPORT NSString *const NSPrintPrinterName;
-APPKIT_EXPORT NSString *const NSPrintJobDisposition;
-APPKIT_EXPORT NSString *const NSPrintDetailedErrorReporting;
+typedef NSString *NSPrintInfoAttributeKey;
 
-APPKIT_EXPORT NSString *const NSPrintSpoolJob;
-APPKIT_EXPORT NSString *const NSPrintPreviewJob;
-APPKIT_EXPORT NSString *const NSPrintSaveJob;
-APPKIT_EXPORT NSString *const NSPrintCancelJob;
+/* Page Setup */
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintPaperName;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintPaperSize;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintOrientation;
+
+/* Pagination */
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintLeftMargin;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintRightMargin;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintTopMargin;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintBottomMargin;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintHorizontallyCentered;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintVerticallyCentered;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintHorizontalPagination;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintVerticalPagination;
+
+/* Other */
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintAllPages;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintCopies;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintDetailedErrorReporting;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintFirstPage;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintHeaderAndFooter;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintJobDisposition;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintJobSavingURL;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintLastPage;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintMustCollate;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintPrinter;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintPrinterName;
+APPKIT_EXPORT NSPrintInfoAttributeKey const NSPrintSelectionOnly;
+
+typedef NSString *NSPrintJobDispositionValue;
+
+APPKIT_EXPORT NSPrintJobDispositionValue const NSPrintSpoolJob;
+APPKIT_EXPORT NSPrintJobDispositionValue const NSPrintPreviewJob;
+APPKIT_EXPORT NSPrintJobDispositionValue const NSPrintSaveJob;
+APPKIT_EXPORT NSPrintJobDispositionValue const NSPrintCancelJob;
 
 APPKIT_EXPORT NSString *const NSPrintSavePath;
-
-APPKIT_EXPORT NSString *const NSPrintCopies;
-APPKIT_EXPORT NSString *const NSPrintAllPages;
-APPKIT_EXPORT NSString *const NSPrintFirstPage;
-APPKIT_EXPORT NSString *const NSPrintLastPage;
-
-APPKIT_EXPORT NSString *const NSPrintPaperName;
-APPKIT_EXPORT NSString *const NSPrintPaperSize;
-APPKIT_EXPORT NSString *const NSPrintOrientation;
-
-APPKIT_EXPORT NSString *const NSPrintHorizontalPagination;
-APPKIT_EXPORT NSString *const NSPrintVerticalPagination;
-
-APPKIT_EXPORT NSString *const NSPrintTopMargin;
-APPKIT_EXPORT NSString *const NSPrintBottomMargin;
-APPKIT_EXPORT NSString *const NSPrintLeftMargin;
-APPKIT_EXPORT NSString *const NSPrintRightMargin;
-APPKIT_EXPORT NSString *const NSPrintHorizontallyCentered;
-APPKIT_EXPORT NSString *const NSPrintVerticallyCentered;
-
-APPKIT_EXPORT NSString *const NSPrintHeaderAndFooter;
-APPKIT_EXPORT NSString *const NSPrintMustCollate;
-APPKIT_EXPORT NSString *const NSPrintSelectionOnly;
 
 @interface NSPrintInfo : NSObject <NSCopying> {
     NSMutableDictionary *_attributes;

--- a/AppKit/include/AppKit/NSSharingService.h
+++ b/AppKit/include/AppKit/NSSharingService.h
@@ -17,7 +17,21 @@
  along with Darling.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#import <AppKit/AppKitExport.h>
 #import <Foundation/NSObject.h>
+
+typedef NSString *NSSharingServiceName;
+
+APPKIT_EXPORT NSSharingServiceName const NSSharingServiceNameAddToIPhoto;
+APPKIT_EXPORT NSSharingServiceName const NSSharingServiceNameComposeEmail;
+APPKIT_EXPORT NSSharingServiceName const NSSharingServiceNameComposeMessage;
+
+/* Deprecated */
+APPKIT_EXPORT NSSharingServiceName const NSSharingServiceNamePostOnFacebook;
+APPKIT_EXPORT NSSharingServiceName const NSSharingServiceNamePostOnLinkedIn;
+APPKIT_EXPORT NSSharingServiceName const NSSharingServiceNamePostOnSinaWeibo;
+APPKIT_EXPORT NSSharingServiceName const NSSharingServiceNamePostOnTencentWeibo;
+APPKIT_EXPORT NSSharingServiceName const NSSharingServiceNamePostOnTwitter;
 
 @interface NSSharingService : NSObject
 @end


### PR DESCRIPTION
This is a continue of [darling#1598](https://github.com/darlinghq/darling/pull/1598) work

<details open><summary>Symbols added</summary>
<p>

  - `_NSPopoverWillShowNotification` ([docs](https://developer.apple.com/documentation/appkit/nspopover/willshownotification?language=objc))
  - `_NSPrintJobSavingURL` ([docs](https://developer.apple.com/documentation/appkit/nsprintinfo/attributekey/jobsavingurl?language=objc))
  - `_NSSharingServiceNamePostOnFacebook` ([docs](https://developer.apple.com/documentation/appkit/nssharingservice/name/postonfacebook?language=objc))
  - `_NSSharingServiceNamePostOnTwitter` ([docs](https://developer.apple.com/documentation/appkit/nssharingservice/name/postontwitter?language=objc))
  - `_NSSharingServiceNamePostOnSinaWeibo` ([docs](https://developer.apple.com/documentation/appkit/nssharingservice/name/postonsinaweibo?language=objc))
  - `_NSSharingServiceNamePostOnTencentWeibo` ([docs](https://developer.apple.com/documentation/appkit/nssharingservice/name/postontencentweibo?language=objc))
  - `_NSSharingServiceNamePostOnLinkedIn` ([docs](https://developer.apple.com/documentation/appkit/nssharingservice/name/postonlinkedin?language=objc))
  - `_NSSharingServiceNameComposeMessage` ([docs](https://developer.apple.com/documentation/appkit/nssharingservice/name/composemessage?language=objc))
  - `_NSSharingServiceNameAddToIPhoto` ([docs](https://developer.apple.com/documentation/appkit/nssharingservice/name/addtoiphoto?language=objc))

</p>
</details> 
