### PR TITLE
Return `self` in initWithCoder method of NSNibAXAttributeConnector

### DIFF
--- a/AppKit/nib.subproj/NSNibAXRelationshipConnector.m
+++ b/AppKit/nib.subproj/NSNibAXRelationshipConnector.m
@@ -22,7 +22,7 @@
 
 - (id) initWithCoder: (NSCoder *) coder {
     printf("STUB %s\n", __PRETTY_FUNCTION__);
-    return [[NSNibAXAttributeConnector alloc] init];
+    return self;
 }
 
 @end


### PR DESCRIPTION
Just a fix to solve what was [commented here](https://github.com/darlinghq/darling-cocotron/pull/56#discussion_r2600040302)