### PR TITLE
Implement MacWorkspace openFile and openURL using LSOpenFromURLSpec

### DIFF
--- a/AppKit/MacWorkspace.m
+++ b/AppKit/MacWorkspace.m
@@ -91,13 +91,16 @@
 {
     // TODO: Implement handling `deactivate` flag
     // TODO: Implement handling race-condition between inter-application (when target app is terminating)
-    
-    if (path == nil) {
-        return NO;
-    }
 
-    NSURL *url = [NSURL fileURLWithPath:path];
+    // On macOS, a nil path with a valid application simply launches the
+    // application (and returns YES), so the file URL is only added when a
+    // path was given.
+    NSURL *url = nil;
     NSURL *appURL = nil;
+
+    if (path != nil) {
+        url = [NSURL fileURLWithPath:path];
+    }
 
     if (application != nil) {
         appURL = [NSURL fileURLWithPath:application];
@@ -106,7 +109,7 @@
     LSLaunchURLSpec spec;
     memset(&spec, 0, sizeof(spec));
 
-    NSArray *urlArray = [NSArray arrayWithObject:url];
+    NSArray *urlArray = (url != nil) ? [NSArray arrayWithObject:url] : nil;
     spec.itemURLs = (CFArrayRef)urlArray;
     spec.appURL = (CFURLRef)appURL;
     spec.launchFlags = kLSLaunchDefaults;

--- a/AppKit/MacWorkspace.m
+++ b/AppKit/MacWorkspace.m
@@ -89,15 +89,45 @@
         withApplication: (NSString *) application
           andDeactivate: (BOOL) deactivate
 {
-    // TODO: call LSOpenFromURLSpec()
-    NSUnimplementedMethod();
-    return NO;
+    if (path == nil) {
+        return NO;
+    }
+
+    NSURL *url = [NSURL fileURLWithPath:path];
+    NSURL *appURL = nil;
+
+    if (application != nil) {
+        appURL = [NSURL fileURLWithPath:application];
+    }
+
+    LSLaunchURLSpec spec;
+    memset(&spec, 0, sizeof(spec));
+
+    NSArray *urlArray = [NSArray arrayWithObject:url];
+    spec.itemURLs = (CFArrayRef)urlArray;
+    spec.appURL = (CFURLRef)appURL;
+    spec.launchFlags = kLSLaunchDefaults;
+
+    OSStatus status = LSOpenFromURLSpec(&spec, NULL);
+
+    return (status == noErr);
 }
 
 - (BOOL) openURL: (NSURL *) url {
-    // TODO: Call LSOpenFromURLSpec()
-    NSUnimplementedMethod();
-    return NO;
+    if (url == nil) {
+        return NO;
+    }
+
+    LSLaunchURLSpec spec;
+    memset(&spec, 0, sizeof(spec));
+
+    NSArray *urlArray = [NSArray arrayWithObject:url];
+    spec.itemURLs = (CFArrayRef)urlArray;
+    spec.launchFlags = kLSLaunchDefaults;
+
+    OSStatus status = LSOpenFromURLSpec(&spec, NULL);
+
+    return (status == noErr);
 }
 
 - (BOOL) selectFile: (NSString *) path

--- a/AppKit/MacWorkspace.m
+++ b/AppKit/MacWorkspace.m
@@ -89,6 +89,9 @@
         withApplication: (NSString *) application
           andDeactivate: (BOOL) deactivate
 {
+    // TODO: Implement handling `deactivate` flag
+    // TODO: Implement handling race-condition between inter-application (when target app is terminating)
+    
     if (path == nil) {
         return NO;
     }


### PR DESCRIPTION
This PR replaces the `NSUnimplementedMethod` stubs in `AppKit/MacWorkspace.m` for `openFile:` and `openURL:` with actual calls to `LSOpenFromURLSpec`.

Because Darling's `LaunchServices` component explicitly intercepts and forwards URLs and non-macOS-native items to the Linux host via `xdg-open`, implementing these basic `NSWorkspace` methods enables macOS GUI applications (and CLI apps depending on Foundation/AppKit) to successfully trigger URL navigation and file opening on the host desktop.