### PR TITLE
Fix per-resize backing-store and shadow-surface leaks in the X11 backend

### DIFF
--- a/AppKit/X11.backend/X11Window.m
+++ b/AppKit/X11.backend/X11Window.m
@@ -440,6 +440,7 @@ static NSData *makeWindowIcon() {
         O2ColorSpaceRelease(colorSpace);
         _context = [[O2Context_builtin_FT alloc] initWithSurface: surface
                                                          flipped: NO];
+        [surface release];
     }
     return _context;
 }

--- a/Onyx2D/O2Context_builtin.m
+++ b/Onyx2D/O2Context_builtin.m
@@ -192,6 +192,7 @@ void O2DContextClipAndFillEdges(O2Context_builtin *self, int fillRuleMask);
                            O2ContextCurrentGState(self)->_shadowOffset.height,
                            size.width, size.height),
                 shadow);
+        [shadow release];
     }
 
     O2ContextDrawLayerInRect(self, O2RectMake(0, 0, size.width, size.height),


### PR DESCRIPTION
Two unreleased `O2Surface` references in the software rendering path:

1. **`-[X11Window createCGContextIfNeeded]`** (`AppKit/X11.backend/X11Window.m`): the freshly allocated surface is passed to `-[O2Context_builtin_FT initWithSurface:flipped:]`, which retains it (see `O2BitmapContext.m`), but the local +1 from `alloc` is never released. Because `-[O2Context resizeWithNewSize:]` unconditionally returns `NO`, the context is torn down and rebuilt on every window resize — stranding one full window-sized backing store (4 bytes/px) per resize. The added `[surface release]` mirrors the pattern already used in `O2BitmapContext.m`'s `initWithBytes:...` convenience initializer.

2. **`-[O2Context_builtin endTransparencyLayer]`** (`Onyx2D/O2Context_builtin.m`): the `shadow` surface created via `createSurfaceWithWidth:height:` is drawn and then never released.

**Measurements** (A/B/A on arm64 Linux, X11 backend, driving unmodified iTerm2): 4,768 KiB leaked per resize before the fix; 419 KiB after, with window shrinks now actually releasing memory; reverting the fix restores the leak exactly (4,767 KiB per resize). No regressions observed across a 12-gate X11 backend test ladder, text rendering, or terminal tab/split workloads.

The deeper fix would be implementing `resizeWithNewSize:` so the context survives resizes, but this is the minimal correct change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
