### PR TITLE
Implement -[X11Window setAlphaValue:] (was an unimplemented abstract method)

### DIFF
--- a/AppKit/X11.backend/X11Window.m
+++ b/AppKit/X11.backend/X11Window.m
@@ -492,6 +492,17 @@ static NSData *makeWindowIcon() {
     _isOpaque = value;
 }
 
+- (void) setAlphaValue: (CGFloat) value {
+    if (value < 0.0) value = 0.0;
+    if (value > 1.0) value = 1.0;
+    unsigned long opacity = (unsigned long)(value * 0xFFFFFFFFUL);
+    XChangeProperty(
+            _display, _window,
+            XInternAtom(_display, "_NET_WM_WINDOW_OPACITY", False),
+            XA_CARDINAL, 32, PropModeReplace,
+            (unsigned char *) &opacity, 1);
+}
+
 - (void) sheetOrderFrontFromFrame: (NSRect) frame
                       aboveWindow: (CGWindow *) aboveWindow
 {


### PR DESCRIPTION
## The gap

`CoreGraphics/CGWindow.m` declares three window-appearance methods as **abstract** — their bodies call `O2InvalidAbstractInvocation()`, so a concrete platform backend is expected to override each one:

- `-setOpaque:`
- `-setHasShadow:`
- `-setAlphaValue:`

The X11 backend, `AppKit/X11.backend/X11Window.m`, overrides the first two — but **never overrode `-setAlphaValue:`**. Any caller that sets a window's alpha therefore trips the abstract trap and the process aborts with:

```
-setAlphaValue: only defined for abstract class. Define -[X11Window setAlphaValue:]
```

This is a latent gap rather than a regression: the sibling overrides sit right next to each other in the same file, so the missing third one is easy to spot once you look.

## The fix

Implement `-setAlphaValue:` in the X11 backend, placed immediately after the existing `-setOpaque:` override, using the standard EWMH per-window opacity hint `_NET_WM_WINDOW_OPACITY` (a `CARDINAL` scaled from the `[0.0, 1.0]` CGFloat to the full 32-bit range). A non-compositing window manager simply ignores the property, so the call is harmless where opacity is unsupported and takes effect where a compositor honours it.

The `XChangeProperty`/`XInternAtom` calls, the `_display`/`_window` ivars, and `<X11/Xatom.h>` (which provides `XA_CARDINAL`) are all already used in this file — no new includes are required.

## Observed effect (arm64 Linux)

On arm64 Linux, an **unmodified iTerm2** build terminates at launch on exactly this exception — no window ever appears. With this override in place the exception is gone: iTerm2 launches and creates its windows normally. The change is a correct standalone abstract-method override and is valuable independent of that particular app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
